### PR TITLE
feat(collections): wire revalidation hooks on Recipes collection

### DIFF
--- a/apps/site/src/collections/Recipes.ts
+++ b/apps/site/src/collections/Recipes.ts
@@ -1,5 +1,9 @@
 import type { CollectionConfig } from 'payload';
 
+import {
+  createRevalidateAfterChange,
+  createRevalidateAfterDelete,
+} from '@/collections/hooks/revalidate-content';
 import { recipeIngredientFields, recipeInstructionFields } from '@/fields/recipeIngredient';
 import { authenticated, publicReadPublished } from '@/lib/payload/access';
 import { slugField } from '@/fields/slugField';
@@ -33,6 +37,10 @@ export const Recipes: CollectionConfig = {
     read: publicReadPublished,
     update: authenticated,
     delete: authenticated,
+  },
+  hooks: {
+    afterChange: [createRevalidateAfterChange('recipes')],
+    afterDelete: [createRevalidateAfterDelete('recipes')],
   },
   fields: [
     {

--- a/apps/site/src/collections/recipes-collections.test.ts
+++ b/apps/site/src/collections/recipes-collections.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/payload/revalidate', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/payload/revalidate')>();
+  return {
+    ...actual,
+    revalidatePaths: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+import { Recipes } from '@/collections/Recipes';
+import { revalidatePaths } from '@/lib/payload/revalidate';
+
+describe('Recipes collection', () => {
+  it('has slug "recipes" and registers required fields', () => {
+    expect(Recipes.slug).toBe('recipes');
+
+    const fieldNames = (Recipes.fields ?? [])
+      .map((field) => ('name' in field ? field.name : undefined))
+      .filter((name): name is string => typeof name === 'string');
+
+    expect(fieldNames).toEqual(
+      expect.arrayContaining([
+        'title',
+        'slug',
+        'date',
+        'author',
+        'excerpt',
+        'ingredients',
+        'instructions',
+      ]),
+    );
+  });
+
+  it('restricts anonymous reads to published recipes', () => {
+    const read = Recipes.access?.read;
+    expect(typeof read).toBe('function');
+
+    if (typeof read === 'function') {
+      expect(read({ req: { user: { id: 1 } } } as never)).toBe(true);
+      expect(read({ req: { user: null } } as never)).toEqual({
+        _status: { equals: 'published' },
+      });
+    }
+  });
+
+  describe('revalidation hooks', () => {
+    beforeEach(() => {
+      vi.mocked(revalidatePaths).mockReset();
+      vi.mocked(revalidatePaths).mockResolvedValue(undefined);
+    });
+
+    it('registers afterChange and afterDelete revalidation hooks', () => {
+      expect(Recipes.hooks?.afterChange?.length).toBeGreaterThanOrEqual(1);
+      expect(Recipes.hooks?.afterDelete?.length).toBeGreaterThanOrEqual(1);
+
+      for (const hook of Recipes.hooks?.afterChange ?? []) {
+        expect(typeof hook).toBe('function');
+      }
+
+      for (const hook of Recipes.hooks?.afterDelete ?? []) {
+        expect(typeof hook).toBe('function');
+      }
+    });
+
+    it('revalidates recipe paths when a recipe is updated', async () => {
+      const afterChange = Recipes.hooks?.afterChange?.[0];
+      expect(typeof afterChange).toBe('function');
+
+      if (typeof afterChange !== 'function') {
+        return;
+      }
+
+      await afterChange({
+        doc: {
+          slug: 'flatbread',
+          title: 'Updated title',
+          _status: 'published',
+        },
+        previousDoc: {
+          slug: 'flatbread',
+          title: 'Original title',
+          _status: 'published',
+        },
+        operation: 'update',
+        collection: { slug: 'recipes' } as never,
+        context: {} as never,
+        data: {},
+        req: { user: { id: 1 } } as never,
+      });
+
+      expect(revalidatePaths).toHaveBeenCalledOnce();
+      const paths = vi.mocked(revalidatePaths).mock.lastCall![0];
+      expect(paths).toContain('/recipes/flatbread/');
+      expect(paths).toContain('/recipes/');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements **CP02-04** — wires Payload `afterChange` and `afterDelete` hooks on the Recipes collection so CMS edits invalidate cached recipe routes without redeploy.

- Adds `hooks.afterChange` and `hooks.afterDelete` to `Recipes.ts` using the shared `createRevalidateAfterChange('recipes')` / `createRevalidateAfterDelete('recipes')` factories (same pattern as Posts in CP02-03)
- Adds `recipes-collections.test.ts` asserting hook registration and that updating a published recipe calls `revalidatePaths` for `/recipes/{slug}/` and `/recipes/`

Related: CP02-04 (`docs/work/content-revalidation/tasks.md`)

## Test plan

- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (41/41 pass, including 4 new Recipes collection tests)
- [ ] CI green on merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Recipe data now automatically refreshes when recipes are updated or deleted, ensuring users always see the most current recipe information.

* **Tests**
  * Added comprehensive test suite for recipe collection functionality, including verification of access controls and automatic data refresh behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->