### PR TITLE
fix(validation): resolve open CodeQL code scanning alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   scaffold:
     name: Toolchain

--- a/apps/site/src/app/api/subscribe/route.ts
+++ b/apps/site/src/app/api/subscribe/route.ts
@@ -1,5 +1,8 @@
 import { NextResponse } from 'next/server';
 
+import { subscribeFormSchema } from '@/src/lib/validation/subscribe-schema';
+import { isSpamEmail } from '@/src/lib/validation/spam-email';
+
 // Simple in-memory rate limiting
 // In production, you should use a Redis or other persistent store
 interface RateLimitRecord {
@@ -65,30 +68,26 @@ function checkRateLimit(
   return { limited, remainingRequests, resetTime };
 }
 
-// Email validation regex
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-
-// Common spam patterns
-const SPAM_EMAIL_PATTERNS = [
-  /test@test/i,
-  /example@/i,
-  /\d{8,}@/i, // emails with 8+ consecutive digits
-  /@(example|test|temp|fake)/i,
-  /[a-z0-9]{20,}@/i, // extremely long email local parts
-];
-
-// Name validation regex - letters, spaces, hyphens, and apostrophes
-const NAME_REGEX = /^[a-zA-Z\s'-]{0,50}$/;
-
-// Check if an email matches common spam patterns
-function isSpamEmail(email: string): boolean {
-  return SPAM_EMAIL_PATTERNS.some((pattern) => pattern.test(email));
-}
-
 export async function POST(req: Request) {
   try {
-    // Parse form data from request
-    const { email, name, interests, website, submissionTime } = await req.json();
+    let body: unknown;
+    try {
+      body = await req.json();
+    } catch {
+      return NextResponse.json({ error: 'Failed to process request' }, { status: 400 });
+    }
+
+    const validation = subscribeFormSchema.safeParse(body);
+    if (!validation.success) {
+      const nameError = validation.error.issues.find((issue) => issue.path[0] === 'name');
+      if (nameError) {
+        return NextResponse.json({ error: nameError.message }, { status: 400 });
+      }
+
+      return NextResponse.json({ error: 'Please provide a valid email address' }, { status: 400 });
+    }
+
+    const { email, name, interests, website, submissionTime } = validation.data;
 
     // 1. Check for honeypot field (should be empty)
     if (website) {
@@ -101,26 +100,13 @@ export async function POST(req: Request) {
       return NextResponse.json({ success: true }, { status: 200 });
     }
 
-    // 3. Validate email format
-    if (!email || !EMAIL_REGEX.test(email)) {
-      return NextResponse.json({ error: 'Please provide a valid email address' }, { status: 400 });
-    }
-
-    // 4. Check for spam email patterns
+    // 3. Check for spam email patterns
     if (isSpamEmail(email)) {
       // Silently reject but report success
       return NextResponse.json({ success: true }, { status: 200 });
     }
 
-    // 5. Validate name (if provided)
-    if (name && !NAME_REGEX.test(name)) {
-      return NextResponse.json(
-        { error: 'Please provide a valid name (letters, spaces, hyphens, and apostrophes only)' },
-        { status: 400 },
-      );
-    }
-
-    // 7. Check email rate limit
+    // 4. Check email rate limit
     const emailLimitResult = checkRateLimit(
       emailRateLimits,
       email,

--- a/apps/site/src/lib/validation/contact-schema.ts
+++ b/apps/site/src/lib/validation/contact-schema.ts
@@ -4,17 +4,7 @@
 
 import { z } from 'zod';
 
-const SPAM_EMAIL_PATTERNS = [
-  /test@test/i,
-  /example@/i,
-  /\d{8,}@/i,
-  /@(example|test|temp|fake|invalid|localhost)/i,
-  /[a-z0-9]{20,}@/i,
-];
-
-function isSpamEmail(email: string): boolean {
-  return SPAM_EMAIL_PATTERNS.some((pattern) => pattern.test(email));
-}
+import { isSpamEmail } from '@/src/lib/validation/spam-email';
 
 /**
  * Inquiry type options

--- a/apps/site/src/lib/validation/sanitize.test.ts
+++ b/apps/site/src/lib/validation/sanitize.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import { sanitizeForEmailGeneration, sanitizePlainText } from '@/src/lib/validation/sanitize';
+
+describe('sanitizePlainText', () => {
+  it('removes angle brackets after decoding HTML entities', () => {
+    expect(sanitizePlainText('&lt;script&gt;alert(1)&lt;/script&gt;')).toBe(
+      'scriptalert(1)/script',
+    );
+  });
+
+  it('strips nested tag bypass payloads', () => {
+    expect(sanitizePlainText('<scrip<script>t>alert(1)</script>t>')).toBe(
+      'scripscripttalert(1)/scriptt',
+    );
+  });
+
+  it('removes malformed close tags that regex parsers can miss', () => {
+    expect(sanitizePlainText('<script>alert(1)</script foo="bar">')).toBe(
+      'scriptalert(1)/script foo="bar"',
+    );
+  });
+});
+
+describe('sanitizeForEmailGeneration', () => {
+  it('escapes plain-text fields embedded in HTML email templates', () => {
+    const sanitized = sanitizeForEmailGeneration({
+      firstName: 'Jane',
+      lastName: 'Doe',
+      email: 'jane@example.com',
+      inquiryType: 'general',
+      message: 'Hello\nworld',
+    });
+
+    expect(sanitized.firstName).toBe('Jane');
+    expect(sanitized.message).toBe('Hello<br>world');
+  });
+
+  it('escapes angle brackets in fields used for HTML output', () => {
+    const sanitized = sanitizeForEmailGeneration({
+      firstName: '<img src=x onerror=alert(1)>',
+      lastName: 'Test',
+      email: 'test@example.com',
+      inquiryType: 'general',
+      message: 'Safe message',
+    });
+
+    expect(sanitized.firstName).toBe('&lt;img src=x onerror=alert(1)&gt;');
+  });
+});

--- a/apps/site/src/lib/validation/sanitize.ts
+++ b/apps/site/src/lib/validation/sanitize.ts
@@ -19,11 +19,8 @@ function decodeHtmlEntities(input: string): string {
   );
 }
 
-function stripHtmlTags(input: string): string {
-  return input
-    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, '')
-    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, '')
-    .replace(/<[^>]*>/g, '');
+function stripAngleBrackets(input: string): string {
+  return input.replace(/[<>]/g, '');
 }
 
 function removeControlCharacters(input: string): string {
@@ -63,7 +60,13 @@ function sanitizeEmailHtml(input: string): string {
 export function sanitizePlainText(input: string | null | undefined): string {
   if (!input) return '';
 
-  return removeControlCharacters(decodeHtmlEntities(stripHtmlTags(input))).trim();
+  return removeControlCharacters(stripAngleBrackets(decodeHtmlEntities(input))).trim();
+}
+
+function sanitizePlainTextForHtml(input: string | null | undefined): string {
+  if (!input) return '';
+
+  return escapeHtml(removeControlCharacters(decodeHtmlEntities(input))).trim();
 }
 
 /**
@@ -111,11 +114,11 @@ export function sanitizeContactFormData(data: ContactFormInput): ContactFormInpu
  */
 export function sanitizeForEmailGeneration(data: ContactFormInput): ContactFormInput {
   return {
-    firstName: sanitizePlainText(data.firstName),
-    lastName: sanitizePlainText(data.lastName),
-    email: sanitizePlainText(data.email),
-    phone: data.phone ? sanitizePlainText(data.phone) : undefined,
-    inquiryType: sanitizePlainText(data.inquiryType),
+    firstName: sanitizePlainTextForHtml(data.firstName),
+    lastName: sanitizePlainTextForHtml(data.lastName),
+    email: sanitizePlainTextForHtml(data.email),
+    phone: data.phone ? sanitizePlainTextForHtml(data.phone) : undefined,
+    inquiryType: sanitizePlainTextForHtml(data.inquiryType),
     message: sanitizeForEmail(data.message), // Preserve line breaks in email
   };
 }

--- a/apps/site/src/lib/validation/spam-email.ts
+++ b/apps/site/src/lib/validation/spam-email.ts
@@ -1,0 +1,11 @@
+const SPAM_EMAIL_PATTERNS = [
+  /test@test/i,
+  /example@/i,
+  /\d{8,}@/i,
+  /@(example|test|temp|fake|invalid|localhost)/i,
+  /[a-z0-9]{20,}@/i,
+];
+
+export function isSpamEmail(email: string): boolean {
+  return SPAM_EMAIL_PATTERNS.some((pattern) => pattern.test(email));
+}

--- a/apps/site/src/lib/validation/subscribe-schema.ts
+++ b/apps/site/src/lib/validation/subscribe-schema.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+export const subscribeFormSchema = z.object({
+  email: z
+    .string()
+    .min(1, 'Please provide a valid email address')
+    .max(254, 'Please provide a valid email address')
+    .email('Please provide a valid email address'),
+  name: z
+    .string()
+    .max(50, 'Please provide a valid name (letters, spaces, hyphens, and apostrophes only)')
+    .regex(
+      /^[a-zA-Z\s'-]*$/,
+      'Please provide a valid name (letters, spaces, hyphens, and apostrophes only)',
+    )
+    .optional(),
+  interests: z.string().optional(),
+  website: z.string().optional(),
+  submissionTime: z.number(),
+});
+
+export type SubscribeFormData = z.infer<typeof subscribeFormSchema>;


### PR DESCRIPTION
## Summary

Closes the six open CodeQL alerts on [code scanning](https://github.com/carinyaparc/website/security/code-scanning):

- Restrict CI workflow `GITHUB_TOKEN` to `contents: read`
- Replace the subscribe route's hand-rolled email regex with Zod validation (ReDoS #10)
- Replace regex-based HTML tag stripping with angle-bracket removal and HTML escaping for email templates (#11–14)
- Extract shared spam-email detection used by contact and subscribe validation

## Test plan

- [x] `pnpm test -- src/lib/validation/sanitize.test.ts`
- [x] `pnpm turbo run lint typecheck --filter=site`
- [ ] Merge to `main` and confirm CodeQL alerts #10–15 close on the next scan

Related: [Code scanning alerts](https://github.com/carinyaparc/website/security/code-scanning)