### PR TITLE
test(collections): add draft access regression tests for Recipes

### DIFF
--- a/apps/site/src/collections/recipes-collections.test.ts
+++ b/apps/site/src/collections/recipes-collections.test.ts
@@ -32,16 +32,26 @@ describe('Recipes collection', () => {
     );
   });
 
-  it('restricts anonymous reads to published recipes', () => {
+  describe('draft access regression', () => {
     const read = Recipes.access?.read;
-    expect(typeof read).toBe('function');
 
-    if (typeof read === 'function') {
-      expect(read({ req: { user: { id: 1 } } } as never)).toBe(true);
-      expect(read({ req: { user: null } } as never)).toEqual({
-        _status: { equals: 'published' },
-      });
-    }
+    it('restricts anonymous reads to published recipes only', () => {
+      expect(typeof read).toBe('function');
+
+      if (typeof read === 'function') {
+        expect(read({ req: { user: null } } as never)).toEqual({
+          _status: { equals: 'published' },
+        });
+      }
+    });
+
+    it('allows authenticated editors to read draft recipes', () => {
+      expect(typeof read).toBe('function');
+
+      if (typeof read === 'function') {
+        expect(read({ req: { user: { id: 1 } } } as never)).toBe(true);
+      }
+    });
   });
 
   describe('revalidation hooks', () => {


### PR DESCRIPTION
## Summary

- Adds explicit draft access regression coverage for the Recipes collection under CP02-05
- Splits anonymous and authenticated read-access assertions into separate scenario-named tests, mirroring the Posts `publicReadPublished` pattern
- Existing Posts access tests remain unchanged and green

Related: CP02-05 (Content revalidation epic)

## Test plan

- [x] `pnpm --filter site test` — 54/54 pass
- [x] Anonymous recipe reads return `{ _status: { equals: 'published' } }` when `req.user` is null
- [x] Authenticated editors receive `true` from the Recipes read access function
- [x] Posts anonymous read restriction test in `blog-collections.test.ts` still passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced verification of recipe access controls to ensure anonymous users can only access published recipes while authenticated editors can view draft content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->