### PR TITLE
feat(consent): add consent API and ConsentGate client bootstrap

### DIFF
--- a/apps/site/src/app/api/consent/route.test.ts
+++ b/apps/site/src/app/api/consent/route.test.ts
@@ -1,0 +1,34 @@
+import { cookies } from 'next/headers';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { GET } from '@/app/api/consent/route';
+
+describe('GET /api/consent', () => {
+  beforeEach(() => {
+    vi.mocked(cookies).mockReset();
+  });
+
+  it('returns null when no cp_consent cookie is present', async () => {
+    vi.mocked(cookies).mockResolvedValue({
+      get: vi.fn().mockReturnValue(undefined),
+    } as never);
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ choice: null });
+  });
+
+  it('returns accepted when the cp_consent cookie is accepted', async () => {
+    vi.mocked(cookies).mockResolvedValue({
+      get: vi.fn().mockReturnValue({ value: 'accepted' }),
+    } as never);
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ choice: 'accepted' });
+  });
+});

--- a/apps/site/src/app/api/consent/route.ts
+++ b/apps/site/src/app/api/consent/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+
+import { getConsent } from '@/lib/consent/get-consent';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const status = await getConsent();
+  return NextResponse.json(status);
+}

--- a/apps/site/src/components/consent/ConsentGate.test.tsx
+++ b/apps/site/src/components/consent/ConsentGate.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@next/third-parties/google', () => ({
+  GoogleTagManager: ({ gtmId }: { gtmId: string }) => (
+    <div data-testid="google-tag-manager" data-gtm-id={gtmId} />
+  ),
+}));
+
+vi.mock('@/lib/consent/actions', () => ({
+  setConsent: vi.fn(),
+}));
+
+describe('ConsentGate', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let ConsentGate: typeof import('@/components/consent/ConsentGate').ConsentGate;
+
+  beforeEach(async () => {
+    vi.stubEnv('NEXT_PUBLIC_GTM_ID', 'GTM-TEST123');
+    vi.resetModules();
+    ({ ConsentGate } = await import('@/components/consent/ConsentGate'));
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it('does not load GTM before consent is accepted', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ choice: null }),
+    } as Response);
+
+    await act(async () => {
+      root.render(<ConsentGate />);
+    });
+
+    await vi.waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith('/api/consent');
+    });
+
+    expect(container.querySelector('[data-testid="google-tag-manager"]')).toBeNull();
+  });
+
+  it('loads GTM after accepted consent', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ choice: 'accepted' }),
+    } as Response);
+
+    await act(async () => {
+      root.render(<ConsentGate />);
+    });
+
+    await vi.waitFor(() => {
+      expect(container.querySelector('[data-testid="google-tag-manager"]')).not.toBeNull();
+    });
+
+    const gtm = container.querySelector('[data-testid="google-tag-manager"]');
+
+    expect(gtm?.getAttribute('data-gtm-id')).toBe('GTM-TEST123');
+  });
+});

--- a/apps/site/src/components/consent/ConsentGate.test.tsx
+++ b/apps/site/src/components/consent/ConsentGate.test.tsx
@@ -76,4 +76,38 @@ describe('ConsentGate', () => {
 
     expect(gtm?.getAttribute('data-gtm-id')).toBe('GTM-TEST123');
   });
+
+  it('shows the banner when the consent API fails', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      json: async () => ({ choice: 'accepted' }),
+    } as Response);
+
+    await act(async () => {
+      root.render(<ConsentGate />);
+    });
+
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain('Accept all');
+    });
+
+    expect(container.querySelector('[data-testid="google-tag-manager"]')).toBeNull();
+  });
+
+  it('shows the banner when the consent API returns an unknown choice', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ choice: 'maybe' }),
+    } as Response);
+
+    await act(async () => {
+      root.render(<ConsentGate />);
+    });
+
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain('Accept all');
+    });
+
+    expect(container.querySelector('[data-testid="google-tag-manager"]')).toBeNull();
+  });
 });

--- a/apps/site/src/components/consent/ConsentGate.tsx
+++ b/apps/site/src/components/consent/ConsentGate.tsx
@@ -6,7 +6,7 @@ import { GoogleTagManager } from '@next/third-parties/google';
 
 import { ConsentBanner } from '@/components/ui/Policy';
 import { setConsent, type ConsentChoice } from '@/lib/consent/actions';
-import type { ConsentStatusResponse } from '@/lib/consent/types';
+import { normalizeConsentChoice, type ConsentStatusResponse } from '@/lib/consent/types';
 
 type ConsentState = ConsentStatusResponse['choice'] | 'loading';
 
@@ -30,7 +30,7 @@ export function ConsentGate() {
         const data = (await response.json()) as ConsentStatusResponse;
 
         if (!cancelled) {
-          setChoice(data.choice);
+          setChoice(normalizeConsentChoice(data.choice));
         }
       } catch {
         if (!cancelled) {

--- a/apps/site/src/components/consent/ConsentGate.tsx
+++ b/apps/site/src/components/consent/ConsentGate.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { GoogleTagManager } from '@next/third-parties/google';
+
+import { ConsentBanner } from '@/components/ui/Policy';
+import { setConsent, type ConsentChoice } from '@/lib/consent/actions';
+import type { ConsentStatusResponse } from '@/lib/consent/types';
+
+type ConsentState = ConsentStatusResponse['choice'] | 'loading';
+
+export function ConsentGate() {
+  const [choice, setChoice] = useState<ConsentState>('loading');
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadConsent() {
+      try {
+        const response = await fetch('/api/consent');
+
+        if (!response.ok) {
+          if (!cancelled) {
+            setChoice(null);
+          }
+          return;
+        }
+
+        const data = (await response.json()) as ConsentStatusResponse;
+
+        if (!cancelled) {
+          setChoice(data.choice);
+        }
+      } catch {
+        if (!cancelled) {
+          setChoice(null);
+        }
+      }
+    }
+
+    void loadConsent();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleConsent = async (consent: ConsentChoice) => {
+    try {
+      const result = await setConsent(consent);
+
+      if (result.success) {
+        setChoice(consent);
+      }
+    } catch (error) {
+      console.error('Failed to set cookie consent:', error);
+    }
+  };
+
+  const showBanner = choice === null;
+  const hasAcceptedAnalytics = choice === 'accepted';
+  const gtmId = process.env.NEXT_PUBLIC_GTM_ID;
+
+  return (
+    <>
+      {hasAcceptedAnalytics && gtmId ? <GoogleTagManager gtmId={gtmId} /> : null}
+      {showBanner ? (
+        <ConsentBanner
+          onAccept={() => void handleConsent('accepted')}
+          onReject={() => void handleConsent('rejected')}
+        />
+      ) : null}
+    </>
+  );
+}

--- a/apps/site/src/components/ui/Policy.tsx
+++ b/apps/site/src/components/ui/Policy.tsx
@@ -5,6 +5,45 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { setConsent, type ConsentChoice } from '@/lib/consent/actions';
 
+interface ConsentBannerProps {
+  onAccept: () => void;
+  onReject: () => void;
+}
+
+export function ConsentBanner({ onAccept, onReject }: ConsentBannerProps) {
+  return (
+    <div className="pointer-events-none fixed inset-x-0 bottom-0 px-6 pb-6 z-50">
+      <div className="pointer-events-auto ml-auto max-w-xl rounded-xl bg-white p-6 shadow-lg ring-1 ring-gray-900/10">
+        <p className="text-sm/6 text-charcoal-600">
+          This website uses cookies to supplement a balanced diet and provide a much deserved reward
+          to the senses after consuming bland but nutritious meals. Accepting our cookies is
+          optional but recommended, as they are delicious. See our{' '}
+          <Link href="/legal/privacy-policy" className="font-semibold text-eucalyptus-600">
+            cookie policy
+          </Link>
+          .
+        </p>
+        <div className="mt-4 flex items-center gap-x-5">
+          <button
+            type="button"
+            onClick={onAccept}
+            className="rounded-md bg-charcoal-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-charcoal-300 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-charcoal-600"
+          >
+            Accept all
+          </button>
+          <button
+            type="button"
+            onClick={onReject}
+            className="text-sm/6 font-semibold text-charcoal-600"
+          >
+            Reject all
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 interface CookiePolicyProps {
   showBanner: boolean;
 }
@@ -31,34 +70,9 @@ export default function CookiePolicy({ showBanner }: CookiePolicyProps) {
   }
 
   return (
-    <div className="pointer-events-none fixed inset-x-0 bottom-0 px-6 pb-6 z-50">
-      <div className="pointer-events-auto ml-auto max-w-xl rounded-xl bg-white p-6 shadow-lg ring-1 ring-gray-900/10">
-        <p className="text-sm/6 text-charcoal-600">
-          This website uses cookies to supplement a balanced diet and provide a much deserved reward
-          to the senses after consuming bland but nutritious meals. Accepting our cookies is
-          optional but recommended, as they are delicious. See our{' '}
-          <Link href="/legal/privacy-policy" className="font-semibold text-eucalyptus-600">
-            cookie policy
-          </Link>
-          .
-        </p>
-        <div className="mt-4 flex items-center gap-x-5">
-          <button
-            type="button"
-            onClick={() => handleConsent('accepted')}
-            className="rounded-md bg-charcoal-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-charcoal-300 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-charcoal-600"
-          >
-            Accept all
-          </button>
-          <button
-            type="button"
-            onClick={() => handleConsent('rejected')}
-            className="text-sm/6 font-semibold text-charcoal-600"
-          >
-            Reject all
-          </button>
-        </div>
-      </div>
-    </div>
+    <ConsentBanner
+      onAccept={() => void handleConsent('accepted')}
+      onReject={() => void handleConsent('rejected')}
+    />
   );
 }

--- a/apps/site/src/lib/consent/get-consent.test.ts
+++ b/apps/site/src/lib/consent/get-consent.test.ts
@@ -1,0 +1,42 @@
+import { cookies } from 'next/headers';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getConsent } from '@/lib/consent/get-consent';
+
+describe('getConsent', () => {
+  beforeEach(() => {
+    vi.mocked(cookies).mockReset();
+  });
+
+  it('returns null when no consent cookie is set', async () => {
+    vi.mocked(cookies).mockResolvedValue({
+      get: vi.fn().mockReturnValue(undefined),
+    } as never);
+
+    await expect(getConsent()).resolves.toEqual({ choice: null });
+  });
+
+  it('returns accepted when the consent cookie is accepted', async () => {
+    vi.mocked(cookies).mockResolvedValue({
+      get: vi.fn().mockReturnValue({ value: 'accepted' }),
+    } as never);
+
+    await expect(getConsent()).resolves.toEqual({ choice: 'accepted' });
+  });
+
+  it('returns rejected when the consent cookie is rejected', async () => {
+    vi.mocked(cookies).mockResolvedValue({
+      get: vi.fn().mockReturnValue({ value: 'rejected' }),
+    } as never);
+
+    await expect(getConsent()).resolves.toEqual({ choice: 'rejected' });
+  });
+
+  it('returns null for an unknown cookie value', async () => {
+    vi.mocked(cookies).mockResolvedValue({
+      get: vi.fn().mockReturnValue({ value: 'maybe' }),
+    } as never);
+
+    await expect(getConsent()).resolves.toEqual({ choice: null });
+  });
+});

--- a/apps/site/src/lib/consent/get-consent.ts
+++ b/apps/site/src/lib/consent/get-consent.ts
@@ -1,0 +1,20 @@
+import 'server-only';
+
+import { cookies } from 'next/headers';
+
+import { CONSENT_COOKIE_NAME } from '@/lib/constants';
+
+import type { ConsentStatusResponse } from '@/lib/consent/types';
+
+export type { ConsentStatusResponse } from '@/lib/consent/types';
+
+export async function getConsent(): Promise<ConsentStatusResponse> {
+  const cookieStore = await cookies();
+  const value = cookieStore.get(CONSENT_COOKIE_NAME)?.value;
+
+  if (value === 'accepted' || value === 'rejected') {
+    return { choice: value };
+  }
+
+  return { choice: null };
+}

--- a/apps/site/src/lib/consent/types.test.ts
+++ b/apps/site/src/lib/consent/types.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeConsentChoice } from '@/lib/consent/types';
+
+describe('normalizeConsentChoice', () => {
+  it('returns accepted for the accepted value', () => {
+    expect(normalizeConsentChoice('accepted')).toBe('accepted');
+  });
+
+  it('returns rejected for the rejected value', () => {
+    expect(normalizeConsentChoice('rejected')).toBe('rejected');
+  });
+
+  it('returns null for null', () => {
+    expect(normalizeConsentChoice(null)).toBe(null);
+  });
+
+  it('returns null for unknown values', () => {
+    expect(normalizeConsentChoice('maybe')).toBe(null);
+    expect(normalizeConsentChoice(undefined)).toBe(null);
+  });
+});

--- a/apps/site/src/lib/consent/types.ts
+++ b/apps/site/src/lib/consent/types.ts
@@ -1,3 +1,13 @@
+export type ConsentChoiceValue = 'accepted' | 'rejected' | null;
+
 export type ConsentStatusResponse = {
-  choice: 'accepted' | 'rejected' | null;
+  choice: ConsentChoiceValue;
 };
+
+export function normalizeConsentChoice(value: unknown): ConsentChoiceValue {
+  if (value === 'accepted' || value === 'rejected') {
+    return value;
+  }
+
+  return null;
+}

--- a/apps/site/src/lib/consent/types.ts
+++ b/apps/site/src/lib/consent/types.ts
@@ -1,0 +1,3 @@
+export type ConsentStatusResponse = {
+  choice: 'accepted' | 'rejected' | null;
+};


### PR DESCRIPTION
## Summary

- Adds `GET /api/consent` (dynamic) and a server-only `getConsent()` helper to read the httpOnly `cp_consent` cookie without forcing the public root layout to call `cookies()`.
- Introduces client `ConsentGate` that fetches consent on mount, shows the banner when no choice is set, and loads GTM only after accepted consent.
- Thins `Policy.tsx` by extracting shared `ConsentBanner` UI; legacy `CookiePolicy` export preserved until CP08-03 wires the layout.

Related: **CP08-02** (Performance epic)

## Test plan

- [x] `pnpm --filter site test` — consent API, helper, normalizer, and ConsentGate GTM gating tests pass
- [x] `pnpm typecheck` and `pnpm lint` pass
- [ ] Manual: `GET /api/consent` returns `{ "choice": null }` with no cookie; `{ "choice": "accepted" }` after accepting via banner (post CP08-03 layout wiring)
- [ ] Confirm `ConsentGate` is mounted and server-side GTM/cookie reads are removed in **CP08-03**