### PR TITLE
Fix sharp native tracing for Linux runtime

### DIFF
--- a/apps/site/next.config.mjs
+++ b/apps/site/next.config.mjs
@@ -1,11 +1,27 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { withPayload } from '@payloadcms/next/withPayload';
 import { withSentryConfig } from '@sentry/nextjs';
 import createMDX from '@next/mdx';
+
+const appDir = path.dirname(fileURLToPath(import.meta.url));
+const monorepoRoot = path.join(appDir, '../..');
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   pageExtensions: ['js', 'jsx', 'md', 'mdx', 'ts', 'tsx'],
   trailingSlash: true,
+  outputFileTracingRoot: monorepoRoot,
+  outputFileTracingIncludes: {
+    '/*': [
+      './node_modules/sharp/**/*',
+      './node_modules/@img/sharp-linux-x64/**/*',
+      './node_modules/@img/sharp-libvips-linux-x64/**/*',
+      '../../node_modules/.pnpm/sharp@*/node_modules/sharp/**/*',
+      '../../node_modules/.pnpm/@img+sharp-linux-x64@*/node_modules/@img/sharp-linux-x64/**/*',
+      '../../node_modules/.pnpm/@img+sharp-libvips-linux-x64@*/node_modules/@img/sharp-libvips-linux-x64/**/*',
+    ],
+  },
 
   async redirects() {
     return [{ source: '/favicon.ico', destination: '/favicon/favicon.ico', permanent: true }];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a monorepo output file tracing root for the site app.
- Force Next.js traces to include sharp and the Linux x64 `@img` native/libvips packages, including pnpm virtual-store paths.

## Validation
- `pnpm --filter site lint` (passes with existing warnings unrelated to this change)
- `pnpm --filter site typecheck`
- `pnpm --filter site build` compiled successfully, then stopped at Payload page-data collection because local Postgres was unavailable and Docker is not installed in this cloud image (`connect ECONNREFUSED localhost:5432`).
- Confirmed the generated `.nft.json` traces include `@img+sharp-linux-x64@0.35.2`, `@img+sharp-libvips-linux-x64@1.3.1`, and `libvips-cpp.so.8.18.3`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de0e9858-f738-4b92-9b8f-7c5e39020db5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de0e9858-f738-4b92-9b8f-7c5e39020db5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app packaging for deployment so image-related features and optimized builds work more reliably in monorepo setups.
  * Updated build tracing so required native image-processing dependencies are consistently included in production bundles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->