### PR TITLE
feat(site): stage-3 WordPress-parity content surfaces — RSS, pagination, recipes index

### DIFF
--- a/apps/site/src/app/(blog)/blog/page.tsx
+++ b/apps/site/src/app/(blog)/blog/page.tsx
@@ -4,7 +4,7 @@ import { PageHeader } from '@/src/components/sections/page-header';
 import { ArrowLeft } from 'lucide-react';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
-import { LatestPosts, FeaturedPosts } from '@/src/components/sections/blog';
+import { FeaturedPosts, PaginatedPosts } from '@/src/components/sections/blog';
 import { SchemaMarkup } from '@/src/components/ui/SchemaMarkup';
 import { Breadcrumb } from '@/src/components/ui/Breadcrumb';
 
@@ -19,9 +19,6 @@ const pageHeaderProps = {
   backgroundImage: '/images/farm-track-gate.jpg',
   backgroundImageAlt: 'Carinya Parc landscape',
 };
-
-// Available post categories
-const categories = ['All', 'Soil Health', 'Biodiversity', 'Water Systems', 'Education', 'Wildlife'];
 
 export const revalidate = 86_400;
 
@@ -57,37 +54,12 @@ export default async function BlogPage() {
         {/* Featured Post Section */}
         <FeaturedPosts limit={1} />
 
-        {/* Category Filter */}
-        <section className="py-8 bg-green-50">
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div className="flex flex-wrap gap-2 justify-center">
-              {categories.map((category) => (
-                <div key={category}>
-                  <Button
-                    variant={category === 'All' ? 'default' : 'outline'}
-                    size="sm"
-                    className={
-                      category === 'All'
-                        ? 'bg-green-600 hover:bg-green-700'
-                        : 'border-green-600 text-green-600 hover:bg-green-50'
-                    }
-                  >
-                    {category}
-                  </Button>
-                </div>
-              ))}
-            </div>
-          </div>
-        </section>
-
         {/* Blog Posts Grid */}
         <section className="py-20 bg-white">
-          <LatestPosts
+          <PaginatedPosts
             title="Recent Articles"
             subtitle="Explore our latest insights and updates from the farm"
-            limit={6}
-            featured={false}
-            viewAllLink=""
+            page={1}
           />
         </section>
       </div>

--- a/apps/site/src/app/(blog)/blog/page/[page]/page.tsx
+++ b/apps/site/src/app/(blog)/blog/page/[page]/page.tsx
@@ -1,0 +1,98 @@
+import { notFound } from 'next/navigation';
+import type { Metadata } from 'next';
+
+import { PageHeader } from '@/src/components/sections/page-header';
+import { PaginatedPosts } from '@/src/components/sections/blog';
+import { Breadcrumb } from '@/src/components/ui/Breadcrumb';
+import { getCachedBlogPostsPage } from '@/lib/payload/cache';
+import { BASE_URL } from '@/src/lib/constants';
+
+const POSTS_PER_PAGE = 6;
+
+const pageHeaderProps = {
+  variant: 'dark' as const,
+  align: 'center' as const,
+  title: 'Life on Pasture',
+  subtitle: 'Our Blog',
+  description:
+    'Follow our regeneration journey through detailed updates, insights, and lessons learned as we transform Carinya Parc into a thriving ecosystem.',
+  backgroundImage: '/images/farm-track-gate.jpg',
+  backgroundImageAlt: 'Carinya Parc landscape',
+};
+
+export const revalidate = 86_400;
+
+function parsePageParam(raw: string): number | null {
+  if (!/^\d+$/.test(raw)) {
+    return null;
+  }
+
+  const page = Number.parseInt(raw, 10);
+  // Page 1 lives at /blog/ — only deeper pages render here.
+  return page >= 2 ? page : null;
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ page: string }>;
+}): Promise<Metadata> {
+  const { page: rawPage } = await params;
+  const page = parsePageParam(rawPage);
+
+  if (!page) {
+    return { title: 'Blog - Carinya Parc' };
+  }
+
+  return {
+    title: `Blog - Page ${page} - Carinya Parc`,
+    description: 'Older articles on regenerative farming and life at Carinya Parc.',
+    alternates: {
+      canonical: `${BASE_URL}/blog/page/${page}/`,
+    },
+  };
+}
+
+export async function generateStaticParams(): Promise<Array<{ page: string }>> {
+  const { totalPages } = await getCachedBlogPostsPage({ page: 1, perPage: POSTS_PER_PAGE });
+
+  return Array.from({ length: Math.max(totalPages - 1, 0) }, (_, index) => ({
+    page: String(index + 2),
+  }));
+}
+
+export default async function BlogPageNumber({ params }: { params: Promise<{ page: string }> }) {
+  const { page: rawPage } = await params;
+  const page = parsePageParam(rawPage);
+
+  if (!page) {
+    notFound();
+  }
+
+  const { totalPages } = await getCachedBlogPostsPage({ page, perPage: POSTS_PER_PAGE });
+
+  if (page > totalPages) {
+    notFound();
+  }
+
+  return (
+    <div className="min-h-screen">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-8">
+        <Breadcrumb />
+      </div>
+
+      <section>
+        <PageHeader {...pageHeaderProps} />
+      </section>
+
+      <section className="py-20 bg-white">
+        <PaginatedPosts
+          title={`Articles — Page ${page}`}
+          subtitle="Explore our insights and updates from the farm"
+          page={page}
+          perPage={POSTS_PER_PAGE}
+        />
+      </section>
+    </div>
+  );
+}

--- a/apps/site/src/app/(recipes)/recipes/page.tsx
+++ b/apps/site/src/app/(recipes)/recipes/page.tsx
@@ -1,0 +1,53 @@
+import type { Metadata } from 'next';
+
+import { PageHeader } from '@/src/components/sections/page-header';
+import { RecipeGrid } from '@/src/components/sections/recipes';
+import { SchemaMarkup } from '@/src/components/ui/SchemaMarkup';
+import { Breadcrumb } from '@/src/components/ui/Breadcrumb';
+import { generatePageMetadata } from '@/src/lib/metadata';
+
+const pageHeaderProps = {
+  variant: 'dark' as const,
+  align: 'center' as const,
+  title: 'From the Hearth',
+  subtitle: 'Our Recipes',
+  description:
+    'Seasonal recipes from the Carinya Parc kitchen — simple, honest cooking built around what the land provides.',
+  backgroundImage: '/images/farm-dam-trees.jpg',
+  backgroundImageAlt: 'Farm dam and trees at Carinya Parc',
+};
+
+export const metadata: Metadata = generatePageMetadata({
+  title: 'Recipes',
+  description:
+    'Seasonal recipes from the Carinya Parc kitchen — simple, honest cooking built around what the land provides.',
+  path: '/recipes',
+  keywords: ['farm recipes', 'seasonal cooking', 'regenerative produce'],
+});
+
+export const revalidate = 86_400;
+
+export default async function RecipesPage() {
+  return (
+    <>
+      <SchemaMarkup type="page" />
+
+      <div className="min-h-screen">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-8">
+          <Breadcrumb />
+        </div>
+
+        <section>
+          <PageHeader {...pageHeaderProps} />
+        </section>
+
+        <section className="py-20 bg-white">
+          <RecipeGrid
+            title="Latest Recipes"
+            subtitle="Cooking from the paddock to the plate, one season at a time"
+          />
+        </section>
+      </div>
+    </>
+  );
+}

--- a/apps/site/src/app/content-routes.isr.test.ts
+++ b/apps/site/src/app/content-routes.isr.test.ts
@@ -29,6 +29,21 @@ describe('content route ISR config', () => {
     const source = readRouteSource('(recipes)/recipes/[slug]/page.tsx');
     expect(source).toMatch(/export const revalidate = 86[_,]?400/);
   });
+
+  it('exports a 24-hour revalidate interval on the recipes listing page', () => {
+    const source = readRouteSource('(recipes)/recipes/page.tsx');
+    expect(source).toMatch(/export const revalidate = 86[_,]?400/);
+  });
+
+  it('exports a 24-hour revalidate interval on paginated blog pages', () => {
+    const source = readRouteSource('(blog)/blog/page/[page]/page.tsx');
+    expect(source).toMatch(/export const revalidate = 86[_,]?400/);
+  });
+
+  it('exports a 24-hour revalidate interval on the RSS feed route', () => {
+    const source = readRouteSource('feed.xml/route.ts');
+    expect(source).toMatch(/export const revalidate = 86[_,]?400/);
+  });
 });
 
 describe('blog section cached queries', () => {

--- a/apps/site/src/app/feed.xml/route.ts
+++ b/apps/site/src/app/feed.xml/route.ts
@@ -1,0 +1,24 @@
+import { getCachedBlogPosts } from '@/lib/payload/cache';
+import { BASE_URL, BLOG_NAME, SITE_DESCRIPTION } from '@/lib/constants';
+import { buildRssFeed } from '@/lib/rss/build-feed';
+
+// ISR fallback; publish-time freshness comes from the payload:posts cache tag
+// plus the /feed.xml path revalidated by the Payload afterChange hooks.
+export const revalidate = 86_400;
+
+export async function GET() {
+  const posts = await getCachedBlogPosts({ limit: 20 });
+
+  const xml = buildRssFeed({
+    posts,
+    baseUrl: BASE_URL,
+    title: BLOG_NAME,
+    description: SITE_DESCRIPTION,
+  });
+
+  return new Response(xml, {
+    headers: {
+      'Content-Type': 'application/rss+xml; charset=utf-8',
+    },
+  });
+}

--- a/apps/site/src/components/sections/blog/PaginatedPosts.tsx
+++ b/apps/site/src/components/sections/blog/PaginatedPosts.tsx
@@ -1,0 +1,40 @@
+import { getCachedBlogPostsPage } from '@/lib/payload/cache';
+
+import PostCard from './PostCard';
+import PaginationNav from './PaginationNav';
+
+interface PaginatedPostsProps {
+  title: string;
+  subtitle: string;
+  page: number;
+  perPage?: number;
+}
+
+export async function PaginatedPosts({ title, subtitle, page, perPage = 6 }: PaginatedPostsProps) {
+  let result;
+  try {
+    result = await getCachedBlogPostsPage({ page, perPage });
+  } catch {
+    return null;
+  }
+
+  const { posts, totalPages } = result;
+
+  return (
+    <div className="mx-auto max-w-7xl px-6 lg:px-8">
+      <div className="mx-auto max-w-2xl text-center">
+        <h2 className="text-4xl font-semibold tracking-tight text-balance text-eucalyptus-600 sm:text-5xl">
+          {title}
+        </h2>
+        <p className="mt-2 text-lg/8 text-eucalyptus-300">{subtitle}</p>
+      </div>
+      <div className="mx-auto mt-16 grid max-w-2xl auto-rows-fr grid-cols-1 gap-8 sm:mt-20 lg:mx-0 lg:max-w-none lg:grid-cols-3">
+        {posts.map((post) => (
+          <PostCard key={post.id} post={post} />
+        ))}
+      </div>
+
+      <PaginationNav currentPage={page} totalPages={totalPages} />
+    </div>
+  );
+}

--- a/apps/site/src/components/sections/blog/PaginationNav.tsx
+++ b/apps/site/src/components/sections/blog/PaginationNav.tsx
@@ -1,0 +1,60 @@
+import Link from 'next/link';
+
+import { cn } from '@/lib/cn';
+
+interface PaginationNavProps {
+  currentPage: number;
+  totalPages: number;
+}
+
+function pageHref(page: number): string {
+  return page <= 1 ? '/blog/' : `/blog/page/${page}/`;
+}
+
+export default function PaginationNav({ currentPage, totalPages }: PaginationNavProps) {
+  if (totalPages <= 1) {
+    return null;
+  }
+
+  const pages = Array.from({ length: totalPages }, (_, index) => index + 1);
+
+  return (
+    <nav aria-label="Blog pages" className="mt-16 flex items-center justify-center gap-2">
+      {currentPage > 1 && (
+        <Link
+          href={pageHref(currentPage - 1)}
+          rel="prev"
+          className="rounded-md px-3 py-2 text-sm font-semibold text-eucalyptus-600 hover:bg-eucalyptus-100"
+        >
+          ← Previous
+        </Link>
+      )}
+
+      {pages.map((page) => (
+        <Link
+          key={page}
+          href={pageHref(page)}
+          aria-current={page === currentPage ? 'page' : undefined}
+          className={cn(
+            'rounded-md px-3.5 py-2 text-sm font-semibold',
+            page === currentPage
+              ? 'bg-eucalyptus-600 text-white'
+              : 'text-eucalyptus-600 hover:bg-eucalyptus-100',
+          )}
+        >
+          {page}
+        </Link>
+      ))}
+
+      {currentPage < totalPages && (
+        <Link
+          href={pageHref(currentPage + 1)}
+          rel="next"
+          className="rounded-md px-3 py-2 text-sm font-semibold text-eucalyptus-600 hover:bg-eucalyptus-100"
+        >
+          Next →
+        </Link>
+      )}
+    </nav>
+  );
+}

--- a/apps/site/src/components/sections/blog/index.ts
+++ b/apps/site/src/components/sections/blog/index.ts
@@ -3,5 +3,7 @@
  * Task: T4.5, T4.6
  */
 export { LatestPosts } from './LatestPosts';
+export { PaginatedPosts } from './PaginatedPosts';
 export { default as FeaturedPosts } from './FeaturedPosts';
 export { default as PostCard } from './PostCard';
+export { default as PaginationNav } from './PaginationNav';

--- a/apps/site/src/components/sections/recipes/RecipeCard.tsx
+++ b/apps/site/src/components/sections/recipes/RecipeCard.tsx
@@ -1,0 +1,48 @@
+import Image from 'next/image';
+import Link from 'next/link';
+
+import type { RecipeListItem } from '@/lib/payload/map-content';
+import { formatIsoDuration } from '@/lib/recipes/format-duration';
+
+interface RecipeCardProps {
+  recipe: RecipeListItem;
+}
+
+export default function RecipeCard({ recipe }: RecipeCardProps) {
+  const meta = [
+    recipe.servings ? `Serves ${recipe.servings}` : null,
+    recipe.totalTime ? formatIsoDuration(recipe.totalTime) : null,
+  ].filter(Boolean);
+
+  return (
+    <article className="relative isolate flex flex-col justify-end overflow-hidden rounded-2xl bg-eucalyptus-600 px-8 pt-80 pb-8 sm:pt-48 lg:pt-80">
+      <Image
+        alt={recipe.title}
+        src={recipe.imageUrl}
+        fill
+        loading="lazy"
+        className="absolute inset-0 -z-10 object-cover"
+        sizes="(max-width: 768px) 100vw, 33vw"
+        quality={80}
+      />
+      <div className="absolute inset-0 -z-10 bg-gradient-to-t from-eucalyptus-600 via-eucalyptus-600/40" />
+      <div className="absolute inset-0 -z-10 rounded-2xl ring-1 ring-eucalyptus-600/10 ring-inset" />
+
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-1 overflow-hidden text-sm/6 text-eucalyptus-200">
+        <time dateTime={recipe.datetime}>{recipe.formattedDate}</time>
+        {meta.length > 0 && <span>{meta.join(' • ')}</span>}
+      </div>
+      <h3 className="mt-3 text-lg/6 font-semibold text-white">
+        <Link href={recipe.href}>
+          <span>
+            <span className="absolute inset-0" />
+            {recipe.title}
+          </span>
+        </Link>
+      </h3>
+      {recipe.description && (
+        <p className="mt-2 line-clamp-2 text-sm/6 text-eucalyptus-100">{recipe.description}</p>
+      )}
+    </article>
+  );
+}

--- a/apps/site/src/components/sections/recipes/RecipeGrid.tsx
+++ b/apps/site/src/components/sections/recipes/RecipeGrid.tsx
@@ -1,0 +1,40 @@
+import { getCachedRecipes } from '@/lib/payload/cache';
+
+import RecipeCard from './RecipeCard';
+
+interface RecipeGridProps {
+  title: string;
+  subtitle: string;
+}
+
+export async function RecipeGrid({ title, subtitle }: RecipeGridProps) {
+  let recipes;
+  try {
+    recipes = await getCachedRecipes();
+  } catch {
+    return null;
+  }
+
+  return (
+    <div className="mx-auto max-w-7xl px-6 lg:px-8">
+      <div className="mx-auto max-w-2xl text-center">
+        <h2 className="text-4xl font-semibold tracking-tight text-balance text-eucalyptus-600 sm:text-5xl">
+          {title}
+        </h2>
+        <p className="mt-2 text-lg/8 text-eucalyptus-300">{subtitle}</p>
+      </div>
+
+      {recipes.length > 0 ? (
+        <div className="mx-auto mt-16 grid max-w-2xl auto-rows-fr grid-cols-1 gap-8 sm:mt-20 lg:mx-0 lg:max-w-none lg:grid-cols-3">
+          {recipes.map((recipe) => (
+            <RecipeCard key={recipe.id} recipe={recipe} />
+          ))}
+        </div>
+      ) : (
+        <p className="mt-16 text-center text-lg text-charcoal-400">
+          Recipes from the hearth are on their way — check back soon.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/site/src/components/sections/recipes/index.ts
+++ b/apps/site/src/components/sections/recipes/index.ts
@@ -1,0 +1,2 @@
+export { RecipeGrid } from './RecipeGrid';
+export { default as RecipeCard } from './RecipeCard';

--- a/apps/site/src/lib/metadata/index.ts
+++ b/apps/site/src/lib/metadata/index.ts
@@ -66,6 +66,9 @@ export async function generateMetadata(
     keywords: [...DEFAULT_KEYWORDS, ...keywords],
     alternates: {
       canonical,
+      types: {
+        'application/rss+xml': `${BASE_URL}/feed.xml`,
+      },
     },
     openGraph: generateOpenGraph({
       title,

--- a/apps/site/src/lib/payload/cache.ts
+++ b/apps/site/src/lib/payload/cache.ts
@@ -4,9 +4,17 @@ import { unstable_cache } from 'next/cache';
 
 import type { Post as PayloadPost, Recipe as PayloadRecipe } from '@/payload-types';
 import type { Post } from '@/lib/posts';
+import type { RecipeListItem } from '@/lib/payload/map-content';
 import { PAYLOAD_CACHE_TAGS } from '@/lib/payload/cache-tags';
-import { getBlogPostBySlug, getBlogPosts, getBlogPostSlugs } from '@/lib/payload/queries/posts';
-import { getRecipeBySlug, getRecipeSlugs } from '@/lib/payload/queries/recipes';
+import {
+  getBlogPostBySlug,
+  getBlogPosts,
+  getBlogPostSlugs,
+  getBlogPostsPage,
+  type BlogPostsPage,
+  type BlogPostsPageOptions,
+} from '@/lib/payload/queries/posts';
+import { getRecipeBySlug, getRecipeSlugs, getRecipes } from '@/lib/payload/queries/recipes';
 
 export { PAYLOAD_CACHE_TAGS } from '@/lib/payload/cache-tags';
 
@@ -43,6 +51,31 @@ export async function getCachedBlogPosts(opts?: BlogPostsOptions): Promise<Post[
   const options = opts ?? {};
   const cached = unstable_cache(() => getBlogPosts(options), blogPostsCacheKey(options), {
     tags: [PAYLOAD_CACHE_TAGS.posts],
+    revalidate: CACHE_REVALIDATE_SECONDS,
+  });
+
+  return cached();
+}
+
+export async function getCachedBlogPostsPage(
+  opts: BlogPostsPageOptions = {},
+): Promise<BlogPostsPage> {
+  const { page = 1, perPage = 6 } = opts;
+  const cached = unstable_cache(
+    () => getBlogPostsPage({ page, perPage }),
+    ['payload', 'posts', 'page', String(page), String(perPage)],
+    {
+      tags: [PAYLOAD_CACHE_TAGS.posts],
+      revalidate: CACHE_REVALIDATE_SECONDS,
+    },
+  );
+
+  return cached();
+}
+
+export async function getCachedRecipes(): Promise<RecipeListItem[]> {
+  const cached = unstable_cache(() => getRecipes(), ['payload', 'recipes', 'list'], {
+    tags: [PAYLOAD_CACHE_TAGS.recipes],
     revalidate: CACHE_REVALIDATE_SECONDS,
   });
 

--- a/apps/site/src/lib/payload/map-content.ts
+++ b/apps/site/src/lib/payload/map-content.ts
@@ -110,6 +110,60 @@ export function mapPayloadRecipeToDetail(doc: PayloadRecipe): RecipeDetail {
   };
 }
 
+/**
+ * Subset of PayloadRecipe fields required to render a recipe card/list item.
+ * Excludes the ingredients and instructions arrays, which only detail needs.
+ */
+export type RecipeListInput = Pick<
+  PayloadRecipe,
+  | 'id'
+  | 'slug'
+  | 'title'
+  | 'date'
+  | 'excerpt'
+  | 'description'
+  | 'image'
+  | 'servings'
+  | 'totalTime'
+  | 'difficulty'
+>;
+
+export type RecipeListItem = {
+  id: number;
+  slug: string;
+  title: string;
+  date: string;
+  formattedDate: string;
+  datetime: string;
+  description: string;
+  excerpt: string;
+  imageUrl: string;
+  servings?: number;
+  totalTime?: string;
+  difficulty?: string;
+  href: string;
+};
+
+export function mapPayloadRecipeToListItem(doc: RecipeListInput, index = 0): RecipeListItem {
+  const fallbackImage = FALLBACK_IMAGES[index % FALLBACK_IMAGES.length] ?? FALLBACK_IMAGES[0];
+
+  return {
+    id: doc.id,
+    slug: doc.slug,
+    title: doc.title,
+    date: doc.date,
+    formattedDate: formatContentDate(doc.date),
+    datetime: doc.date,
+    description: doc.description ?? doc.excerpt,
+    excerpt: doc.excerpt,
+    imageUrl: doc.image ?? fallbackImage,
+    servings: doc.servings ?? undefined,
+    totalTime: doc.totalTime ?? undefined,
+    difficulty: doc.difficulty ?? undefined,
+    href: recipeUrl(doc.slug),
+  };
+}
+
 export type ContentRouteEntry = {
   route: string;
   lastModified: string;

--- a/apps/site/src/lib/payload/queries/posts.ts
+++ b/apps/site/src/lib/payload/queries/posts.ts
@@ -10,6 +10,31 @@ type BlogPostsOptions = {
   featured?: boolean;
 };
 
+export type BlogPostsPageOptions = {
+  page?: number;
+  perPage?: number;
+};
+
+export type BlogPostsPage = {
+  posts: Post[];
+  page: number;
+  totalPages: number;
+  totalDocs: number;
+};
+
+// Positive projection for fields consumed by mapPayloadPostToListItem.
+// Excludes body (heavy JSONB) and tags/category relationships to avoid posts_rels joins.
+const POST_LIST_SELECT = {
+  title: true,
+  slug: true,
+  date: true,
+  author: true,
+  excerpt: true,
+  description: true,
+  image: true,
+  featured: true,
+} as const;
+
 export async function getBlogPosts(opts: BlogPostsOptions = {}): Promise<Post[]> {
   const { limit, featured = false } = opts;
   const payload = await getPayloadClient();
@@ -22,18 +47,7 @@ export async function getBlogPosts(opts: BlogPostsOptions = {}): Promise<Post[]>
     depth: 1,
     limit: limit ?? 100,
     sort: '-date',
-    // Positive projection for fields consumed by mapPayloadPostToListItem.
-    // Excludes body (heavy JSONB) and tags/category relationships to avoid posts_rels joins.
-    select: {
-      title: true,
-      slug: true,
-      date: true,
-      author: true,
-      excerpt: true,
-      description: true,
-      image: true,
-      featured: true,
-    },
+    select: POST_LIST_SELECT,
     ...(featured
       ? {
           where: {
@@ -46,6 +60,30 @@ export async function getBlogPosts(opts: BlogPostsOptions = {}): Promise<Post[]>
   });
 
   return result.docs.map((doc, index) => mapPayloadPostToListItem(doc as PostListInput, index));
+}
+
+export async function getBlogPostsPage(opts: BlogPostsPageOptions = {}): Promise<BlogPostsPage> {
+  const { page = 1, perPage = 6 } = opts;
+  const payload = await getPayloadClient();
+
+  const result = await payload.find({
+    collection: 'posts',
+    // Local API bypasses access control by default; enforce publicReadPublished
+    // so drafts never reach public surfaces.
+    overrideAccess: false,
+    depth: 1,
+    page,
+    limit: perPage,
+    sort: '-date',
+    select: POST_LIST_SELECT,
+  });
+
+  return {
+    posts: result.docs.map((doc, index) => mapPayloadPostToListItem(doc as PostListInput, index)),
+    page: result.page ?? page,
+    totalPages: result.totalPages ?? 1,
+    totalDocs: result.totalDocs ?? result.docs.length,
+  };
 }
 
 export async function getBlogPostBySlug(slug: string): Promise<PayloadPost | null> {

--- a/apps/site/src/lib/payload/queries/public-queries-access.test.ts
+++ b/apps/site/src/lib/payload/queries/public-queries-access.test.ts
@@ -8,11 +8,17 @@ vi.mock('@/lib/payload/client', () => ({
   getPayloadClient: vi.fn().mockResolvedValue({ find }),
 }));
 
-import { getBlogPostBySlug, getBlogPosts, getBlogPostSlugs } from '@/lib/payload/queries/posts';
+import {
+  getBlogPostBySlug,
+  getBlogPosts,
+  getBlogPostSlugs,
+  getBlogPostsPage,
+} from '@/lib/payload/queries/posts';
 import {
   getRecipeBySlug,
   getRecipeSitemapEntries,
   getRecipeSlugs,
+  getRecipes,
 } from '@/lib/payload/queries/recipes';
 import { getPostSitemapEntries } from '@/lib/payload/queries/sitemap-posts';
 
@@ -23,9 +29,11 @@ import { getPostSitemapEntries } from '@/lib/payload/queries/sitemap-posts';
  */
 const publicQueries: Array<[string, () => Promise<unknown>]> = [
   ['getBlogPosts', () => getBlogPosts({ limit: 3 })],
+  ['getBlogPostsPage', () => getBlogPostsPage({ page: 2 })],
   ['getBlogPostBySlug', () => getBlogPostBySlug('a-post')],
   ['getBlogPostSlugs', () => getBlogPostSlugs()],
   ['getPostSitemapEntries', () => getPostSitemapEntries()],
+  ['getRecipes', () => getRecipes()],
   ['getRecipeBySlug', () => getRecipeBySlug('a-recipe')],
   ['getRecipeSlugs', () => getRecipeSlugs()],
   ['getRecipeSitemapEntries', () => getRecipeSitemapEntries()],

--- a/apps/site/src/lib/payload/queries/recipes.ts
+++ b/apps/site/src/lib/payload/queries/recipes.ts
@@ -2,9 +2,43 @@ import 'server-only';
 
 import type { Recipe as PayloadRecipe } from '@/payload-types';
 import { getPayloadClient } from '@/lib/payload/client';
-import { mapPayloadDocToRoute, mapPayloadRecipeToDetail } from '@/lib/payload/map-content';
-import type { ContentRouteEntry } from '@/lib/payload/map-content';
+import {
+  mapPayloadDocToRoute,
+  mapPayloadRecipeToDetail,
+  mapPayloadRecipeToListItem,
+} from '@/lib/payload/map-content';
+import type { ContentRouteEntry, RecipeListInput, RecipeListItem } from '@/lib/payload/map-content';
 import { recipeUrl } from '@/lib/payload/urls';
+
+export async function getRecipes(opts: { limit?: number } = {}): Promise<RecipeListItem[]> {
+  const { limit = 100 } = opts;
+  const payload = await getPayloadClient();
+
+  const result = await payload.find({
+    collection: 'recipes',
+    // Local API bypasses access control by default; enforce publicReadPublished
+    // so drafts never reach public surfaces.
+    overrideAccess: false,
+    depth: 0,
+    limit,
+    sort: '-date',
+    // Positive projection for the listing page; excludes ingredients and
+    // instructions arrays, which only the detail page needs.
+    select: {
+      title: true,
+      slug: true,
+      date: true,
+      excerpt: true,
+      description: true,
+      image: true,
+      servings: true,
+      totalTime: true,
+      difficulty: true,
+    },
+  });
+
+  return result.docs.map((doc, index) => mapPayloadRecipeToListItem(doc as RecipeListInput, index));
+}
 
 export async function getRecipeBySlug(slug: string): Promise<PayloadRecipe | null> {
   const payload = await getPayloadClient();

--- a/apps/site/src/lib/payload/revalidate.test.ts
+++ b/apps/site/src/lib/payload/revalidate.test.ts
@@ -24,6 +24,10 @@ describe('normalizeRevalidatePath', () => {
   it('leaves the root path unchanged', () => {
     expect(normalizeRevalidatePath('/')).toBe('/');
   });
+
+  it('leaves file-style routes without a trailing slash', () => {
+    expect(normalizeRevalidatePath('/feed.xml')).toBe('/feed.xml');
+  });
 });
 
 describe('getPostRevalidationPaths', () => {
@@ -38,7 +42,8 @@ describe('getPostRevalidationPaths', () => {
 
     expect(paths).toContain('/blog/');
     expect(paths).toContain('/blog/my-post/');
-    expect(paths.every((path) => path.endsWith('/'))).toBe(true);
+    expect(paths).toContain('/feed.xml');
+    expect(paths.every((path) => path.endsWith('/') || path.includes('.'))).toBe(true);
   });
 
   it('always includes the home path for any post change', () => {

--- a/apps/site/src/lib/payload/revalidate.ts
+++ b/apps/site/src/lib/payload/revalidate.ts
@@ -11,11 +11,17 @@ export type RevalidationContext = {
   operation: 'create' | 'update' | 'delete';
 };
 
-/** Normalise to trailing-slash paths for next.config trailingSlash: true */
+/**
+ * Normalise to trailing-slash paths for next.config trailingSlash: true.
+ * Paths whose final segment contains a dot (e.g. /feed.xml) are file-style
+ * routes that Next serves without a trailing slash, so they pass through.
+ */
 export function normalizeRevalidatePath(path: string): string {
   let normalized = path.startsWith('/') ? path : `/${path}`;
 
-  if (normalized !== '/' && !normalized.endsWith('/')) {
+  const lastSegment = normalized.slice(normalized.lastIndexOf('/') + 1);
+
+  if (normalized !== '/' && !normalized.endsWith('/') && !lastSegment.includes('.')) {
     normalized = `${normalized}/`;
   }
 
@@ -27,9 +33,11 @@ function uniqueNormalizedPaths(paths: string[]): string[] {
 }
 
 export function getPostRevalidationPaths(ctx: RevalidationContext): string[] {
-  // Always revalidate the blog index and homepage — the "Latest Posts" section
-  // on the homepage shows the most recent posts regardless of featured status.
-  const paths: string[] = ['/blog/', '/'];
+  // Always revalidate the blog index, homepage, and RSS feed — the "Latest
+  // Posts" section on the homepage shows the most recent posts regardless of
+  // featured status. Paginated /blog/page/N/ routes are refreshed via the
+  // payload:posts cache tag rather than enumerating page paths here.
+  const paths: string[] = ['/blog/', '/', '/feed.xml'];
   const slug = ctx.doc.slug;
 
   if (slug) {

--- a/apps/site/src/lib/performance/static-route-assertion.test.ts
+++ b/apps/site/src/lib/performance/static-route-assertion.test.ts
@@ -15,7 +15,7 @@ import {
 const SITE_ROOT = path.resolve(import.meta.dirname, '../../..');
 const BUILD_MANIFEST_PATH = path.join(SITE_ROOT, '.next/prerender-manifest.json');
 
-const KEY_CONTENT_ROUTES = ['/', '/blog/', '/blog/[slug]', '/recipes/[slug]'] as const;
+const KEY_CONTENT_ROUTES = ['/', '/blog/', '/blog/[slug]', '/recipes/', '/recipes/[slug]'] as const;
 
 const SAMPLE_BUILD_OUTPUT = `
 Route (app)                                                 Revalidate  Expire

--- a/apps/site/src/lib/rss/build-feed.test.ts
+++ b/apps/site/src/lib/rss/build-feed.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Post } from '@/lib/posts';
+import { buildRssFeed } from '@/lib/rss/build-feed';
+
+function makePost(overrides: Partial<Post> = {}): Post {
+  return {
+    id: 1,
+    slug: 'my-post',
+    title: 'My Post',
+    date: '2026-06-01',
+    formattedDate: 'June 1, 2026',
+    datetime: '2026-06-01',
+    tags: [],
+    excerpt: 'Excerpt text',
+    description: 'Description text',
+    author: 'Jonathan Daddia',
+    authorImageUrl: '/images/placeholder.jpg',
+    imageUrl: '/images/hero-home.jpg',
+    featured: false,
+    href: '/blog/my-post/',
+    ...overrides,
+  };
+}
+
+describe('buildRssFeed', () => {
+  const baseOptions = {
+    baseUrl: 'https://carinyaparc.com.au',
+    title: 'Carinya Parc Blog',
+    description: 'Life on Pasture',
+  };
+
+  it('builds a valid RSS 2.0 channel with item links from post hrefs', () => {
+    const xml = buildRssFeed({ ...baseOptions, posts: [makePost()] });
+
+    expect(xml).toContain('<rss version="2.0"');
+    expect(xml).toContain('<title>Carinya Parc Blog</title>');
+    expect(xml).toContain('<link>https://carinyaparc.com.au/blog/</link>');
+    expect(xml).toContain('<link>https://carinyaparc.com.au/blog/my-post/</link>');
+    expect(xml).toContain(
+      '<guid isPermaLink="true">https://carinyaparc.com.au/blog/my-post/</guid>',
+    );
+    expect(xml).toContain(
+      '<atom:link href="https://carinyaparc.com.au/feed.xml" rel="self" type="application/rss+xml"/>',
+    );
+  });
+
+  it('escapes XML entities in titles and descriptions', () => {
+    const xml = buildRssFeed({
+      ...baseOptions,
+      posts: [makePost({ title: 'Soil & Water <update>', description: 'A "quoted" note' })],
+    });
+
+    expect(xml).toContain('<title>Soil &amp; Water &lt;update&gt;</title>');
+    expect(xml).toContain('<description>A &quot;quoted&quot; note</description>');
+    expect(xml).not.toContain('<update>');
+  });
+
+  it('renders an empty channel without items when there are no posts', () => {
+    const xml = buildRssFeed({ ...baseOptions, posts: [] });
+
+    expect(xml).toContain('<channel>');
+    expect(xml).not.toContain('<item>');
+  });
+});

--- a/apps/site/src/lib/rss/build-feed.ts
+++ b/apps/site/src/lib/rss/build-feed.ts
@@ -1,0 +1,70 @@
+import type { Post } from '@/lib/posts';
+
+export type RssFeedOptions = {
+  posts: Post[];
+  baseUrl: string;
+  title: string;
+  description: string;
+  feedPath?: string;
+};
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function toRfc822(dateString: string): string {
+  const date = new Date(dateString);
+  return Number.isNaN(date.getTime()) ? new Date().toUTCString() : date.toUTCString();
+}
+
+/**
+ * Build an RSS 2.0 feed document for the blog.
+ * Kept as a pure function so the XML shape is unit-testable without a route.
+ */
+export function buildRssFeed({
+  posts,
+  baseUrl,
+  title,
+  description,
+  feedPath = '/feed.xml',
+}: RssFeedOptions): string {
+  const feedUrl = `${baseUrl}${feedPath}`;
+  const lastBuildDate = posts[0] ? toRfc822(posts[0].date) : new Date().toUTCString();
+
+  const items = posts
+    .map((post) => {
+      const link = `${baseUrl}${post.href}`;
+
+      return [
+        '    <item>',
+        `      <title>${escapeXml(post.title)}</title>`,
+        `      <link>${escapeXml(link)}</link>`,
+        `      <guid isPermaLink="true">${escapeXml(link)}</guid>`,
+        `      <pubDate>${toRfc822(post.date)}</pubDate>`,
+        `      <description>${escapeXml(post.description || post.excerpt)}</description>`,
+        '    </item>',
+      ].join('\n');
+    })
+    .join('\n');
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">',
+    '  <channel>',
+    `    <title>${escapeXml(title)}</title>`,
+    `    <link>${escapeXml(`${baseUrl}/blog/`)}</link>`,
+    `    <description>${escapeXml(description)}</description>`,
+    '    <language>en-au</language>',
+    `    <lastBuildDate>${lastBuildDate}</lastBuildDate>`,
+    `    <atom:link href="${escapeXml(feedUrl)}" rel="self" type="application/rss+xml"/>`,
+    items,
+    '  </channel>',
+    '</rss>',
+    '',
+  ].join('\n');
+}

--- a/docs/architecture/solution.md
+++ b/docs/architecture/solution.md
@@ -465,7 +465,7 @@ Formal ADR files are not yet authored. Candidate decisions recorded here; bodies
 - In-memory rate limiting on contact and subscribe APIs (not reliable on serverless).
 - Archived MDX under `content/posts/` and `content/recipes/` (not runtime source).
 - Unused MDX dependencies in `package.json` (`gray-matter`, remark packages).
-- Non-functional blog category filter UI vs Payload categories.
+- Category/tag archive pages not yet implemented (decorative filter UI removed; Categories and Tags collections exist but drive no public surface).
 - Public consent and analytics bootstrap via `GET /api/consent` and client `ConsentGate` (replaces
   dynamic layout `cookies()` reads for GTM).
 - Unused `/api/media/file/**` rewrite without Media collection.

--- a/docs/architecture/structure.md
+++ b/docs/architecture/structure.md
@@ -73,13 +73,15 @@ Within `apps/site`, the primary directories relevant to web behaviour are:
     - `contact/page.tsx` – contact form.
 
   - `(blog)/` – routing group for blog content (shared site root layout):
-    - `blog/page.tsx` – blog index at `/blog`.
+    - `blog/page.tsx` – blog index at `/blog` (page 1 + pagination).
+    - `blog/page/[page]/page.tsx` – paginated archive at `/blog/page/{n}`.
     - `blog/[slug]/page.tsx` – individual post at `/blog/{slug}` (Payload-backed).
     - Future: `blog/category/[slug]/page.tsx`, `blog/tag/[tag]/page.tsx`.
 
   - `(recipes)/` – routing group for recipe content (shared site root layout):
+    - `recipes/page.tsx` – recipes index at `/recipes`.
     - `recipes/[slug]/page.tsx` – individual recipe at `/recipes/{slug}` (Payload-backed).
-    - Future: `recipes/page.tsx`, `recipes/category/[slug]/page.tsx`, `recipes/tag/[tag]/page.tsx`.
+    - Future: `recipes/category/[slug]/page.tsx`, `recipes/tag/[tag]/page.tsx`.
 
   - `api/` – API route handlers (`subscribe`, `contact`, `sentry`, `cron`).
   - `global-error.tsx`, `not-found.tsx`, `sitemap.ts`, and other app-wide files.
@@ -160,8 +162,11 @@ The current route structure includes (not exhaustive):
 - `/about/jonathan` → `src/app/(www)/about/jonathan/page.tsx`.
 - `/regenerate` → `src/app/(www)/regenerate/page.tsx`.
 - `/blog` → `src/app/(blog)/blog/page.tsx`.
+- `/blog/page/[page]` → `src/app/(blog)/blog/page/[page]/page.tsx`.
 - `/blog/[slug]` → `src/app/(blog)/blog/[slug]/page.tsx`.
+- `/recipes` → `src/app/(recipes)/recipes/page.tsx`.
 - `/recipes/[slug]` → `src/app/(recipes)/recipes/[slug]/page.tsx`.
+- `/feed.xml` → `src/app/feed.xml/route.ts` (RSS 2.0 feed of blog posts).
 - `/legal/[slug]` → `src/app/(www)/legal/[slug]/page.tsx`.
 - `/subscribe` → `src/app/(www)/subscribe/page.tsx`.
 - `/contact` → `src/app/(www)/contact/page.tsx`.
@@ -180,7 +185,7 @@ Route groups are structural only (they do not change URLs):
 
 - `(www)/` – marketing, legal, contact, subscribe.
 - `(blog)/` – blog index and posts.
-- `(recipes)/` – recipe detail pages.
+- `(recipes)/` – recipes index and detail pages.
 - `(payload)/` – Payload admin and CMS API (separate root layout).
 
 If additional groups are introduced (e.g. `(functional)` for booking flows), document them here.


### PR DESCRIPTION
## Summary

Implements the first tranche of stage 3 ("WordPress parity") from the July 2026 site review (`docs/reviews/2026-07-03-site-codebase-review.md`), following #85 and #86.

## Changes

### RSS feed (review §5)
- New `GET /feed.xml` — RSS 2.0 feed of the 20 latest published posts, built by a pure, unit-tested feed builder (`lib/rss/build-feed.ts`) with XML escaping, `atom:link rel="self"`, and `en-au` language.
- RSS discovery `<link rel="alternate" type="application/rss+xml">` added to root metadata.
- Freshness: ISR fallback (`revalidate = 86400`) plus on-publish revalidation — `/feed.xml` is now in the post revalidation paths, and `normalizeRevalidatePath` learned to pass file-style paths through without appending a trailing slash (unit-tested).

### Blog pagination (review §5)
- `/blog/` shows page 1 (6 posts) with a pagination nav; older posts live at `/blog/page/2/`, `/blog/page/3/`, … via `generateStaticParams`. Previously posts beyond the latest 6 were unreachable by navigation.
- New `getBlogPostsPage` query (shares the list projection, `overrideAccess: false`) with a page-keyed `unstable_cache` wrapper tagged `payload:posts`, so publish-time tag revalidation refreshes paginated pages.
- Paginated routes have self-canonical metadata, `rel=prev/next` links, `aria-current` on the active page, and 404 for invalid/out-of-range page numbers.

### Recipes index (review §5)
- New `/recipes/` listing page — recipe detail pages were orphaned (reachable only by URL). Includes a new recipe list query + mapper (projection excludes ingredient/instruction arrays), cached wrapper tagged `payload:recipes`, `RecipeGrid`/`RecipeCard` sections, and an empty state for when no recipes are published.
- The existing Payload hooks already revalidate `/recipes/` on publish; the sitemap picks the route up automatically.
- The "Cook — From The Hearth" nav item stays hidden (`visible: false`) — flip it in `src/app/navigation.tsx` when you're happy with the published recipe content.

### Category filter removed (review §5)
- The blog index's category buttons were decorative — announced as interactive, wired to nothing. Removed; category/tag archive pages remain tracked in `solution.md` §10 as future work.

### Tests and docs
- Access-enforcement regression test now covers the two new queries (9 public queries total); ISR source assertions cover the new routes; the postbuild static-route check includes `/recipes/`; new RSS builder test suite.
- `structure.md` route maps and `solution.md` debt list updated.

## Not in this PR (rest of stage 3)
- **Archived MDX migration** — needs Payload/database access to create content; best done via the admin or a migration script run with DB credentials.
- **Search** and **dynamic OG images** — larger features, proposed as separate PRs.
- **Dependabot alert triage** — needs repository security access.

## Verification

- `pnpm lint` — 0 errors
- `pnpm typecheck` — clean
- `pnpm format:check` — clean
- `pnpm test` — 139 passed / 5 skipped (9 new tests)

Note: `/blog/page/[page]` and `/recipes/` render from `generateStaticParams`/ISR at build time — the Vercel preview build is the end-to-end check that they classify as static/ISR (the postbuild route-classification test also asserts this when run after `pnpm site:build`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RBrgyH4YDqwTdPhHjQ7J3B

---
_Generated by [Claude Code](https://claude.ai/code/session_01RBrgyH4YDqwTdPhHjQ7J3B)_