### PR TITLE
docs(architecture): fix prettier formatting in principles.md

### DIFF
--- a/docs/architecture/principles.md
+++ b/docs/architecture/principles.md
@@ -1,6 +1,6 @@
 # Guiding Principles
 
-Engineering rules for the Carinya Parc website.   |
+Engineering rules for the Carinya Parc website. |
 
 1. **Separation of Concerns:** Modules **SHALL** adhere to the single‑responsibility principle. UI components **SHALL NOT** contain side‑effects such as data fetching or business logic.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`docs/architecture/principles.md` had a trailing-whitespace formatting issue that fails `pnpm format:check` (and the `Quality checks` CI job) on `main`. This is blocking `Quality checks` on any PR rebased onto `main`, including #93.

## Changes

- Ran `pnpm format` (Prettier) — only whitespace change in `docs/architecture/principles.md`.

## Testing

- `pnpm format:check` passes locally after the fix.
- No other files changed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6fcedd60-0519-43e1-97d6-871d1c659c80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6fcedd60-0519-43e1-97d6-871d1c659c80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected minor formatting in the engineering principles documentation without changing its content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->