### PR TITLE
docs: grow the product monorepo instead of flattening

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Carinya Parc ([carinyaparc.com.au](https://carinyaparc.com.au)) is a working rur
 
 - **Primary app:** `apps/site` — Next.js 16 (App Router) with Payload CMS 3, Postgres, Tailwind CSS 4, and React 19.
 - **Content:** Blog posts and recipes from Payload (Postgres); legal pages from MDX in `content/legal/`.
-- **Shared packages:** `@repo/eslint-config`, `@repo/typescript-config`. UI primitives live in the app at `apps/site/src/components/ui/` (built on Base UI).
+- **Shared packages:** `@carinya/theme` (design tokens; package landing in Phase 3), `@repo/eslint-config`, `@repo/typescript-config`. UI primitives live in the app at `apps/site/src/components/ui/` (built on Base UI).
 - **Deployment:** Vercel (production). Payload admin at `/admin`; public marketing site, blog, and recipes share a common site root layout.
 
 For product context and feature intent, read `docs/product.md` (what and why). For delivery phasing, read `docs/product/roadmap.md` (when). For architecture and debt, read `docs/architecture/solution.md` (how; §10). For routing and folders, read `docs/architecture/structure.md` (where). For engineering rules, read `docs/architecture/principles.md`.
@@ -33,10 +33,14 @@ For product context and feature intent, read `docs/product.md` (what and why). F
 │           ├── hooks/        # Client hooks (use-*)
 │           ├── lib/          # Cross-cutting utilities (payload client, security/, …)
 │           ├── providers/    # App-wide React providers
-│           └── styles/       # Global CSS
+│           └── styles/       # Site CSS (components, page overrides)
 ├── packages/
-│   ├── eslint-config/
-│   └── typescript-config/
+│   ├── carinya-theme/        # @carinya/theme — CSS-first Tailwind 4 tokens
+│   ├── eslint-config/        # @repo/eslint-config
+│   └── typescript-config/    # @repo/typescript-config
+├── brand/                    # Voice and positioning markdown (not a workspace package)
+├── skills/
+│   └── carinya-parc/         # Product-local agent skill (not a workspace package)
 └── docs/                     # product/, architecture/, work/
 ```
 
@@ -115,7 +119,7 @@ pnpm turbo run build --filter=site
 - Use `cn()` from `@/lib/cn` for conditional Tailwind classes.
 - Reuse primitives from `@/components/ui` before adding new low-level UI.
 
-**Styling:** Tailwind CSS 4 — `tailwind.config.ts`, `postcss.config.mjs`, and theme tokens in `src/styles/globals.css`.
+**Styling:** Tailwind CSS 4. Design tokens live in `packages/carinya-theme` (`@carinya/theme`). Site-specific CSS stays in `apps/site/src/styles/` (`globals.css`, `components.css`, page overrides). `tailwind.config.ts` and `postcss.config.mjs` remain in the site app. Until the theme package lands, production tokens are still in `apps/site/src/styles/carinya-tokens.css`.
 
 **Architecture (from `docs/architecture/principles.md`):**
 

--- a/docs/architecture/solution.md
+++ b/docs/architecture/solution.md
@@ -4,7 +4,7 @@ scope: carinyaparc-website
 version: '0.1'
 owner: engineering
 status: Draft
-last_updated: 2026-07-02
+last_updated: 2026-08-13
 related:
   - docs/product/product.md
   - docs/architecture/principles.md
@@ -106,7 +106,7 @@ Ordered by priority for architectural trade-offs.
 - Australian English for user-visible copy ([`product.md`](product.md)).
 - Single property, single editor today — RBAC and multi-tenant patterns deferred.
 - Build-time static generation currently queries Postgres (`generateStaticParams`) — CI and Vercel builds require database connectivity and secrets.
-- Monorepo shape today (`apps/site` + `packages/*`); consolidation to a flat repo is a future structural change, not current runtime behaviour.
+- Monorepo shape today (`apps/site` + `packages/*`); the repo grows as a product monorepo (`packages/carinya-theme`, `brand/`, `skills/`). It is not flattened to a single app.
 
 ---
 
@@ -493,7 +493,7 @@ Formal ADR files are not yet authored. Candidate decisions recorded here; bodies
 - **Rate limit store:** Vercel KV vs Upstash vs other?
 - **Media migration:** Backfill strategy for existing public-path images when upload collection is added?
 - **Globals scope:** Which marketing surfaces move to Payload Globals vs remain in code?
-- **Repo flatten timing:** Entry criteria beyond roadmap exit checks?
+- **Repo flatten timing:** _Superseded._ The monorepo grows (`@carinya/theme`, `brand/`, `skills/`); it is not collapsed to a single app. See [`product/roadmap.md`](../product/roadmap.md) Phase 3.
 
 Mitigation timing is in [`product/roadmap.md`](product/roadmap.md). Do not track debt elsewhere in this doc set.
 

--- a/docs/architecture/structure.md
+++ b/docs/architecture/structure.md
@@ -1,6 +1,6 @@
 # Project Structure
 
-**Where** code and routes live — folder layout, naming, and conventions for `apps/site`.
+**Where** code and routes live — folder layout, naming, and conventions for the product monorepo and `apps/site`.
 
 | Doc                                           | Role                            |
 | --------------------------------------------- | ------------------------------- |
@@ -33,14 +33,18 @@ At a high level, the monorepo is structured as:
 │       │   ├── hooks/        # Reusable hooks
 │       │   ├── providers/    # App-wide React context providers
 │       │   ├── lib/          # Cross-cutting utilities (payload client, security, …)
-│       │   ├── styles/       # Global and component-level styles
+│       │   ├── styles/       # Site CSS (components, page overrides)
 │       ├── eslint.config.mjs
 │       ├── next.config.mjs
 │       ├── tailwind.config.ts
 │       └── vitest.config.mjs
 ├── packages/
+│   ├── carinya-theme/        # @carinya/theme — CSS-first Tailwind 4 tokens
 │   ├── eslint-config/        # Shared ESLint configuration
 │   └── typescript-config/    # Shared TypeScript configs
+├── brand/                    # Voice and positioning markdown (not a workspace package)
+├── skills/
+│   └── carinya-parc/         # Product-local agent skill (not a workspace package)
 ├── docs/                     # Documentation (product/, architecture/, work/)
 ├── pnpm-workspace.yaml
 ├── pnpm-lock.yaml
@@ -49,6 +53,10 @@ At a high level, the monorepo is structured as:
 ```
 
 The `docs/` directory contains [`product/product.md`](../product/product.md), architecture docs in [`architecture/`](.) ([`solution.md`](solution.md), [`principles.md`](principles.md)), [`product/roadmap.md`](../product/roadmap.md), and this file. Update the relevant doc alongside code changes.
+
+`pnpm-workspace.yaml` includes `apps/*` and `packages/*` only. `brand/` and `skills/` are source trees, not installable packages.
+
+Until `@carinya/theme` lands, production tokens remain in `apps/site/src/styles/carinya-tokens.css` (copied from the design-system repo). Site-specific CSS stays in `apps/site/src/styles/` after extraction.
 
 ## Site App Structure (`apps/site`)
 
@@ -148,7 +156,7 @@ Within `apps/site`, the primary directories relevant to web behaviour are:
   - Other cross-cutting library code.
 
 - `src/styles/`
-  - `globals.css`, `components.css`, typography, and page-level overrides.
+  - `globals.css`, `components.css`, and page-level overrides. Design tokens belong in `packages/carinya-theme` (`@carinya/theme`); until that package lands they live in `carinya-tokens.css` here.
 
 - `vitest.config.mjs`, `vitest.setup.ts` – Vitest config; tests colocated under `src/`
 

--- a/docs/product/roadmap.md
+++ b/docs/product/roadmap.md
@@ -1,10 +1,10 @@
 ---
 type: Roadmap
 domain: carinya-parc-website
-version: '0.3'
+version: '0.4'
 owner: product
 status: Draft
-last_updated: 2026-06-17
+last_updated: 2026-08-13
 parent_product: docs/product.md
 parent_roadmap: null
 related:
@@ -41,9 +41,9 @@ Each phase unlocks the next without stacking risky changes.
 
 1. **Marketing and editorial outcomes first** — Stay information, publishable posts and recipes with assets and SEO, and editable key site copy address guest pipeline, brand-building, and daily content work from [`product.md`](../product.md).
 2. **Production hardening woven in, not blocking content** — CI lands early so CMS and marketing changes merge safely; shared rate limits and production admin verification follow once editors are actively publishing.
-3. **Live editing before repo surgery** — Content changes must appear on the public site without redeploy. Prove the Payload + Next.js integration in production before collapsing the monorepo.
+3. **Live editing before shared-package extraction** — Content changes must appear on the public site without redeploy. Prove the Payload + Next.js integration in production before growing `packages/`.
 4. **Editorial foundations before full page CMS** — Media, SEO, and site globals address daily editing without migrating every marketing page into Payload.
-5. **Repo simplification after stability** — Flatten to a single Next.js app only once CMS behaviour is proven in production.
+5. **Grow the product monorepo after stability** — Extract `@carinya/theme` and colocate brand markdown and product-local skills once CMS behaviour is proven. Do not flatten to a single app.
 6. **Discoverability after the content model settles** — Syndication, social previews, and richer structured data depend on stable media and recipe fields.
 
 ---
@@ -85,7 +85,7 @@ Each phase unlocks the next without stacking risky changes.
 - [ ] Draft content never appears on the public site (verified after any access changes).
 - [ ] CI runs lint, typecheck, test, and build on pull requests; build succeeds with production-equivalent database and CMS secrets.
 
-**Out of scope:** Full page CMS for about, contact, and regenerate routes; scheduled publishing; multi-user roles beyond basic admin/editor; legal MDX migration; site search; shared rate limiting; repo flattening; RSS; dynamic social images.
+**Out of scope:** Full page CMS for about, contact, and regenerate routes; scheduled publishing; multi-user roles beyond basic admin/editor; legal MDX migration; site search; shared rate limiting; theme package extraction; RSS; dynamic social images.
 
 ---
 
@@ -112,35 +112,37 @@ Each phase unlocks the next without stacking risky changes.
 - [ ] Single clear content source of truth in the repository and database.
 - [ ] Misleading or non-functional UI removed or corrected (including blog category filter if not yet addressed).
 
-**Out of scope:** New CMS schema or marketing pages; media uploads; SEO plugin; repo flattening; RSS; dynamic social images.
+**Out of scope:** New CMS schema or marketing pages; media uploads; SEO plugin; theme package extraction; RSS; dynamic social images.
 
 **Entry condition:** Phase 1 exit criteria met, or Phase 1 in progress with revalidation and CI already landed (rate limiting and production verification may proceed in parallel once CI is green).
 
 ---
 
-### Phase 3 — Repo consolidation
+### Phase 3 — Shared theme and product monorepo
 
-**Objective:** Collapse the monorepo to a single deployable Next.js app, reducing tooling overhead.
+**Objective:** Grow the existing pnpm + Turborepo into a product monorepo — extract design tokens into `@carinya/theme`, and colocate brand markdown and product-local skills. Do not flatten to a single app.
 
 **In scope:**
 
-- Move shared UI into the application.
-- Inline lint and TypeScript configuration at the repository root. (Tailwind inlined in `apps/site`.)
-- Promote the site app to repo root; remove workspace orchestration and the packages folder.
-- Update deployment configuration and normalise import paths.
+- Add `packages/carinya-theme` (`@carinya/theme`) from the production token CSS; the site consumes it via `@import '@carinya/theme'`.
+- Add `brand/` (voice, positioning) as the markdown source of truth for agents and humans.
+- Add `skills/carinya-parc` for product-local agent guidance.
+- Keep UI primitives in `apps/site/src/components/ui/` (no `packages/ui` or `packages/icons`).
 
 **Quality gates:**
 
-- Single-app repository builds, tests, and deploys with no functional regression.
+- Site build, tests, and Tailwind utilities (`eucalypt-*` and semantic tokens) are unchanged in behaviour.
+- No copied `carinya-tokens.css` remains in the site app.
+- Engineering docs (`structure.md`, `AGENTS.md`) match the tree.
 
 **Exit criteria:**
 
-- [ ] Repository root is one Next.js + Payload application.
-- [ ] Dev, test, build, and CI pass on the flat structure.
-- [ ] Production deployment succeeds from the new root.
-- [ ] Import paths and engineering docs reflect the flat layout.
+- [ ] `@carinya/theme` is a workspace package; the site imports it and no longer copies tokens.
+- [ ] `brand/voice.md` and `brand/positioning.md` are the voice/positioning source of truth in this repo.
+- [ ] `skills/carinya-parc` resolves paths inside this repository.
+- [ ] UI stays inlined in `apps/site`; lint and TypeScript configs stay as `@repo/*` packages.
 
-**Out of scope:** New product features, CMS schema changes, legal MDX migration.
+**Out of scope:** Flattening to a single Next.js app; extracting a UI or icon package; merging the agents compiler or carinya-plugins; publishing `@carinya/theme` to npm; new product features or CMS schema changes.
 
 **Entry condition:** Phase 2 exit criteria met and a stable production editing period with no critical CMS regressions.
 
@@ -188,7 +190,7 @@ Each phase unlocks the next without stacking risky changes.
 | CI green on every PR                  | 1     | Internal only     | Woven hardening — safe merges during CMS work |
 | Production admin verified             | 2     | Internal only     | Security headers + env checklist              |
 | Shared form rate limiting             | 2     | Internal only     | Reliable abuse resistance                     |
-| Flat single-app repository            | 3     | No                | Reduced maintenance overhead                  |
+| `@carinya/theme` in the monorepo      | 3     | No                | Tokens as a workspace package, not a copy     |
 | RSS feed live                         | 4     | Yes               | New distribution channel                      |
 | Rich social previews                  | 4     | Yes               | When links are shared                         |
 | Experiences and partner pages         | 4     | Yes               | Marketing scaffolding for future offers       |
@@ -204,7 +206,7 @@ Each phase unlocks the next without stacking risky changes.
 | On-demand revalidation (Next.js + Payload) | Engineering           | Phase 1 — live editorial workflow  | Not started |
 | SEO plugin (Payload)                       | Engineering           | Phase 1 — per-document SEO         | Not started |
 | Shared rate-limit store                    | Engineering           | Phase 2 — reliable form protection | Not started |
-| Vercel project root change                 | Engineering / hosting | Phase 3 — flat repo deploy         | Not started |
+| Design-token package (`@carinya/theme`)    | Engineering           | Phase 3 — stop copying tokens      | Not started |
 
 ---
 


### PR DESCRIPTION
## Summary
- Replace roadmap Phase 3 (flatten to a single app) with a product-monorepo plan: `@carinya/theme`, `brand/`, and `skills/carinya-parc`.
- Update `solution.md`, `structure.md`, and `AGENTS.md` so the documented tree matches that direction.
- UI stays inlined in `apps/site`; no ADR in this PR.

## Test plan
- [x] Docs-only — no runtime change
- [ ] Skim Phase 3 in `docs/product/roadmap.md` and the trees in `AGENTS.md` / `structure.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture documentation to reflect the growing monorepo structure and shared theme package.
  * Clarified workspace organization, design-token placement, and site-specific styling ownership.
  * Revised the product roadmap to prioritize shared theme extraction and related brand and skills documentation.
  * Updated document version and last-updated metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->