### PR TITLE
docs: add brand voice, positioning, and product skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ Carinya Parc ([carinyaparc.com.au](https://carinyaparc.com.au)) is a working rur
 - **Primary app:** `apps/site` — Next.js 16 (App Router) with Payload CMS 3, Postgres, Tailwind CSS 4, and React 19.
 - **Content:** Blog posts and recipes from Payload (Postgres); legal pages from MDX in `content/legal/`.
 - **Shared packages:** `@carinya/theme` (design tokens), `@repo/eslint-config`, `@repo/typescript-config`. UI primitives live in the app at `apps/site/src/components/ui/` (built on Base UI).
+- **Brand:** `brand/voice.md` and `brand/positioning.md`. Product skill: `skills/carinya-parc/SKILL.md`.
 - **Deployment:** Vercel (production). Payload admin at `/admin`; public marketing site, blog, and recipes share a common site root layout.
 
 For product context and feature intent, read `docs/product.md` (what and why). For delivery phasing, read `docs/product/roadmap.md` (when). For architecture and debt, read `docs/architecture/solution.md` (how; §10). For routing and folders, read `docs/architecture/structure.md` (where). For engineering rules, read `docs/architecture/principles.md`.

--- a/brand/positioning.md
+++ b/brand/positioning.md
@@ -1,0 +1,29 @@
+# Carinya Parc — Positioning
+
+Canonical positioning for this repository. Humans edit this file. Agents read it; they do not change it without an explicit request.
+
+## Who we are
+
+Carinya Parc is a working regenerative farm at The Branch, Upper Hunter NSW — 42 hectares being healed back into a peaceful home for land, food and community. Carinya is an Aboriginal word meaning "peaceful home."
+
+## Who we are for
+
+People within reach of the Hunter and the Mid-North Coast who care where their food comes from and want to be closer to it: home cooks buying better beef, families who visit, volunteers who plant, and the growing audience who follow land restoration because they are weighing a version of it themselves.
+
+Secondary: practitioners — smallholders and career-changers restoring degraded ground who want evidence rather than vibes.
+
+## What we claim
+
+- We are restoring degraded grazing land, and **we publish the measurements** — wins and setbacks alike. Baselines first, claims after.
+- We raise Highland cattle on pasture and sell nutrient-conscious food with the provenance visible.
+- We open the gate: people can come, plant, learn and eat here.
+
+We never claim to be the cheapest, the biggest, or a finished restoration. Enthusiasm does not override the measurements.
+
+## Where we compete
+
+Not on price, not on volume, not on being the biggest regenerative voice in Australia. We compete on **being the documented, visitable, evidence-first example**: the farm you can actually stand on, run by someone who measures everything and shows the working. Twenty adequate posts lose to one everyone quotes; we play the depth game.
+
+## The one-line test
+
+If a piece of content could have been published by any lifestyle farm account, it is off-positioning. Ours carries a measurement, a method, or an open gate.

--- a/brand/voice.md
+++ b/brand/voice.md
@@ -1,0 +1,37 @@
+# Carinya Parc — Voice
+
+Canonical voice for this repository. Agents and humans read this file; do not change it unless asked.
+
+## Who is speaking
+
+Jonno — first person plural for the farm ("we", "our"), addressing the reader as "you". A strategic leader who traded the boardroom for a pair of boots. Evidence-based rigour, told across the fence.
+
+"We treat the land as borrowed from our grandkids." Speak plainly and invite people in.
+
+## Register
+
+Warm, plain, grounded, quietly playful. Hopeful without being preachy. Never greenwashed — where we have numbers we show them; where we don't, we say we're still measuring.
+
+Signature line: "A peaceful home for land, food & community."
+
+## Person and casing
+
+- First person plural ("we", "our"); address the reader as "you".
+- Sentence case everywhere except the wordmark and eyebrows (UPPERCASE, letterspaced).
+- Australian English. DD/MM/YYYY. Metric.
+- No emoji.
+
+## Rules
+
+- Lead with the point. Short sentences. Concrete nouns from this place: paddock, creek, eucalypt, herd.
+- Measurements over adjectives. "0.4% soil carbon lift over four years" beats "dramatically healthier soil". Concrete over abstract ("42 hectares", "30,000 trees") — evidence, not slogans.
+- Publish setbacks with the same energy as wins. Open books are the brand.
+- Invite, don't lecture. The reader is a guest, not a student.
+- Humour is dry and small. Never at the reader's expense.
+
+## Never
+
+- Corporate filler: leverage, utilise, synergy, holistic, cutting-edge, streamline, robust, paradigm.
+- Greenwash: eco-friendly, planet-positive, guilt-free, "good for the planet".
+- Hype stacks: "truly unique", "absolutely stunning", three-adjective pileups.
+- Hedged mush: "arguably", "in many ways", "it could be said".

--- a/docs/architecture/structure.md
+++ b/docs/architecture/structure.md
@@ -56,6 +56,8 @@ The `docs/` directory contains [`product/product.md`](../product/product.md), ar
 
 `pnpm-workspace.yaml` includes `apps/*` and `packages/*` only. `brand/` and `skills/` are source trees, not installable packages.
 
+Voice and positioning live in `brand/voice.md` and `brand/positioning.md`. The product skill is `skills/carinya-parc/SKILL.md`.
+
 Design tokens live in `packages/carinya-theme` (`@carinya/theme`). Site-specific CSS stays in `apps/site/src/styles/`.
 
 ## Site App Structure (`apps/site`)

--- a/docs/product/roadmap.md
+++ b/docs/product/roadmap.md
@@ -137,10 +137,10 @@ Each phase unlocks the next without stacking risky changes.
 
 **Exit criteria:**
 
-- [ ] `@carinya/theme` is a workspace package; the site imports it and no longer copies tokens.
-- [ ] `brand/voice.md` and `brand/positioning.md` are the voice/positioning source of truth in this repo.
-- [ ] `skills/carinya-parc` resolves paths inside this repository.
-- [ ] UI stays inlined in `apps/site`; lint and TypeScript configs stay as `@repo/*` packages.
+- [x] `@carinya/theme` is a workspace package; the site imports it and no longer copies tokens.
+- [x] `brand/voice.md` and `brand/positioning.md` are the voice/positioning source of truth in this repo.
+- [x] `skills/carinya-parc` resolves paths inside this repository.
+- [x] UI stays inlined in `apps/site`; lint and TypeScript configs stay as `@repo/*` packages.
 
 **Out of scope:** Flattening to a single Next.js app; extracting a UI or icon package; merging the agents compiler or carinya-plugins; publishing `@carinya/theme` to npm; new product features or CMS schema changes.
 

--- a/skills/carinya-parc/SKILL.md
+++ b/skills/carinya-parc/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: carinya-parc
+description: >-
+  Applies Carinya Parc brand voice, positioning, and visual tokens when writing
+  copy or building UI for the farm website (Upper Hunter NSW). Use when drafting
+  site copy, CMS seeds, or branded interfaces; when choosing colours, type, or
+  radius; or when the user mentions Carinya brand, voice, or design tokens.
+---
+
+Read `brand/voice.md` and `brand/positioning.md` before writing copy. Read
+`packages/carinya-theme/README.md` and `packages/carinya-theme/css/tokens.css`
+before choosing colour, type, radius, or shadow.
+
+If invoked without a brief, ask what to build (production site vs throwaway
+prototype) and whether the output is copy, UI, or both.
+
+## Copy
+
+- Follow `brand/voice.md` (we/our, sentence case, no emoji, measurements over adjectives).
+- Pass the one-line test in `brand/positioning.md`. Off-positioning copy does not ship.
+- Australian English. Signature line: "A peaceful home for land, food & community."
+
+## Visual
+
+Production tokens: `@import '@carinya/theme'` (already in `apps/site/src/styles/globals.css`).
+Do not copy tokens into the site app.
+
+- Headings: Marcellus (`font-heading`), weight 400. Body/UI: Hanken Grotesk (`font-sans`).
+- Lead with eucalypt (`eucalypt-600` / `--color-primary`). Kangaroo gold and bracken as accents. Wattle only for tiny highlights. Warm neutrals (paperbark ground, fleece surfaces) — never cool greys.
+- Over-round: large container radii, `rounded-pill` for buttons/inputs/tags. No sharp corners.
+- Soft warm shadows. Hover darkens one ramp step. Focus ring is eucalypt.
+- Photography: real land, warm golden-hour light, full-bleed. No stock pastoral gloss.
+- UI icons: Lucide at stroke-width ~2.6. No emoji. Wordmark **CARINYA PARC** in Marcellus; **CP** monogram for squares. No pictorial mark.
+
+## Production vs prototype
+
+- **Production (this repo):** reuse `apps/site/src/components/ui/` (Base UI + Tailwind). Do not invent a parallel component set. Site-specific CSS stays in `apps/site/src/styles/`.
+- **Throwaway mocks:** static HTML is fine; still use token names and the visual rules above. Do not treat design-system JSX as a production import.
+
+HTML brand decks and specimen cards live in the sibling `design-system` repo (studio only). They are not the token or voice source of truth.


### PR DESCRIPTION
## Summary
- Add canonical `brand/voice.md` and `brand/positioning.md` in this repo (reconciled from agents/brand and the design-system voice rules).
- Add `skills/carinya-parc` pointing at `brand/`, `@carinya/theme`, and inlined site UI.
- Point `AGENTS.md` / `structure.md` at those paths; mark Phase 3 brand/skill exit criteria done.

## Test plan
- [x] Skill paths resolve: `brand/voice.md`, `brand/positioning.md`, `packages/carinya-theme/README.md`, `packages/carinya-theme/css/tokens.css`
- [x] `pnpm-workspace.yaml` still only `apps/*` and `packages/*`
- [x] No HTML brand decks copied
- [ ] Skim `skills/carinya-parc/SKILL.md` and `brand/voice.md` for accuracy