### PR TITLE
feat(theme): add type scale and stand alone from design-system

### DIFF
--- a/brand/positioning.md
+++ b/brand/positioning.md
@@ -1,6 +1,6 @@
 # Carinya Parc — Positioning
 
-Canonical positioning for this repository. Humans edit this file. Agents read it; they do not change it without an explicit request.
+Canonical positioning for Carinya Parc. Humans edit this file. Agents read it; they do not change it without an explicit request.
 
 ## Who we are
 

--- a/docs/architecture/structure.md
+++ b/docs/architecture/structure.md
@@ -71,6 +71,7 @@ Within `apps/site`, the primary directories relevant to web behaviour are:
 
 - `public/`
   - `images/` – photography and UI placeholders. Use kebab-case, subject-descriptor names (e.g. `hero-home.jpg`, `farm-track-gate.jpg`); keep `404.jpg` for the not-found page.
+  - `motifs/` – brand line icons (leaf, hills, sun, branch, sprout, grass).
   - `favicon/` – favicon.ico and PNG sizes; `logo.png`, `robots.txt`, `site.webmanifest`, etc.
 
 - `src/app/`

--- a/packages/carinya-theme/README.md
+++ b/packages/carinya-theme/README.md
@@ -6,4 +6,37 @@ CSS-first Tailwind CSS 4 theme for Carinya Parc. Production token source of trut
 @import '@carinya/theme';
 ```
 
-Site-specific CSS (`@plugin` typography, component utilities, page overrides) stays in `apps/site`.
+Site-specific CSS (`@plugin` typography, component utilities, page overrides) stays in `apps/site`. Fonts load via `next/font` (`--font-hanken`, `--font-marcellus`); this package does not `@import` Google Fonts.
+
+## What this package owns
+
+All brand tokens live in `css/tokens.css` as a single `@theme` block (plus `.dark` semantic overrides). Tailwind v4 prefixes colour tokens as `--color-*`.
+
+| Token family                                                   | In `@theme`       | Notes                                                                      |
+| -------------------------------------------------------------- | ----------------- | -------------------------------------------------------------------------- |
+| Colour ramps (eucalypt, kangaroo, bracken, branch, wattle)     | Yes               | Full 50–900 ramps; hero is `eucalypt-600`                                  |
+| Warm neutrals (bark, charcoal, stone, line, paperbark, fleece) | Yes               |                                                                            |
+| Semantic colours (background, primary, muted, ring, charts, …) | Yes               | Also inverse, footer, highlight, popover                                   |
+| Radius (`sm`–`xl`, `pill`, default `1rem`)                     | Yes               |                                                                            |
+| Warm shadows (`sm` / `md` / `lg`)                              | Yes               |                                                                            |
+| Type scale (`text-display` … `text-eyebrow`)                   | Yes               | Utilities: `text-h1`, `text-body`, `tracking-eyebrow`, `tracking-wordmark` |
+| Spacing                                                        | Tailwind defaults | 4px grid: spacing `1` = 4px … `20` = 80px                                  |
+| Border width                                                   | Tailwind default  | 1px                                                                        |
+
+Do not copy tokens into `apps/site`. Do not keep a parallel vanilla `:root` sheet.
+
+## Type utilities
+
+| Class                                                  | Size              | Default line-height / extras                        |
+| ------------------------------------------------------ | ----------------- | --------------------------------------------------- |
+| `text-display`                                         | 64px              | 1.05                                                |
+| `text-h1`                                              | 48px              | 1.15                                                |
+| `text-h2`                                              | 34px              | 1.15                                                |
+| `text-h3`                                              | 24px              | 1.15                                                |
+| `text-body-lg`                                         | 19px              | 1.6                                                 |
+| `text-body`                                            | 17px              | 1.6                                                 |
+| `text-small`                                           | 14px              |                                                     |
+| `text-eyebrow`                                         | 13px              | tracking 0.24em, weight 600 — still add `uppercase` |
+| `tracking-eyebrow`                                     | 0.24em            |                                                     |
+| `tracking-wordmark`                                    | 0.3em             |                                                     |
+| `leading-display` / `leading-heading` / `leading-body` | 1.05 / 1.15 / 1.6 |                                                     |

--- a/packages/carinya-theme/css/tokens.css
+++ b/packages/carinya-theme/css/tokens.css
@@ -8,6 +8,30 @@
   --font-sans: var(--font-hanken), system-ui, -apple-system, sans-serif;
   --font-heading: var(--font-marcellus), Georgia, serif;
 
+  --text-display: 64px;
+  --text-display--line-height: 1.05;
+  --text-h1: 48px;
+  --text-h1--line-height: 1.15;
+  --text-h2: 34px;
+  --text-h2--line-height: 1.15;
+  --text-h3: 24px;
+  --text-h3--line-height: 1.15;
+  --text-body-lg: 19px;
+  --text-body-lg--line-height: 1.6;
+  --text-body: 17px;
+  --text-body--line-height: 1.6;
+  --text-small: 14px;
+  --text-eyebrow: 13px;
+  --text-eyebrow--letter-spacing: 0.24em;
+  --text-eyebrow--font-weight: 600;
+
+  --leading-display: 1.05;
+  --leading-heading: 1.15;
+  --leading-body: 1.6;
+
+  --tracking-eyebrow: 0.24em;
+  --tracking-wordmark: 0.3em;
+
   /* ---- Eucalypt (primary · foliage green) ---- */
   --color-eucalypt-50: #eaf0ea;
   --color-eucalypt-100: #d3e1d6;

--- a/skills/carinya-parc/SKILL.md
+++ b/skills/carinya-parc/SKILL.md
@@ -5,6 +5,7 @@ description: >-
   copy or building UI for the farm website (Upper Hunter NSW). Use when drafting
   site copy, CMS seeds, or branded interfaces; when choosing colours, type, or
   radius; or when the user mentions Carinya brand, voice, or design tokens.
+user-invocable: true
 ---
 
 Read `brand/voice.md` and `brand/positioning.md` before writing copy. Read
@@ -26,15 +27,15 @@ Production tokens: `@import '@carinya/theme'` (already in `apps/site/src/styles/
 Do not copy tokens into the site app.
 
 - Headings: Marcellus (`font-heading`), weight 400. Body/UI: Hanken Grotesk (`font-sans`).
+- Type: `text-display` / `text-h1`–`text-h3` / `text-body` / `text-eyebrow`. Eyebrows are UPPERCASE with `tracking-eyebrow` (0.24em). Wordmark uses `tracking-wordmark` (0.3em).
 - Lead with eucalypt (`eucalypt-600` / `--color-primary`). Kangaroo gold and bracken as accents. Wattle only for tiny highlights. Warm neutrals (paperbark ground, fleece surfaces) — never cool greys.
-- Over-round: large container radii, `rounded-pill` for buttons/inputs/tags. No sharp corners.
-- Soft warm shadows. Hover darkens one ramp step. Focus ring is eucalypt.
-- Photography: real land, warm golden-hour light, full-bleed. No stock pastoral gloss.
-- UI icons: Lucide at stroke-width ~2.6. No emoji. Wordmark **CARINYA PARC** in Marcellus; **CP** monogram for squares. No pictorial mark.
+- Over-round: `rounded-lg`–`rounded-xl` on containers (24–28px), `rounded-pill` for buttons/inputs/tags. No sharp corners.
+- Soft warm shadows (`shadow-sm` / `md` / `lg`). Hover darkens one ramp step. Focus ring is eucalypt. Transitions ~150ms, no bounce. Selection may use a wattle tint.
+- Photography: real land, warm golden-hour light, full-bleed. No stock pastoral gloss. Files in `apps/site/public/images/`.
+- Motifs: `apps/site/public/motifs/` (leaf, hills, sun, branch, sprout, grass) at 2.6px stroke. UI icons: Lucide at stroke-width ~2.6. No emoji.
+- Wordmark **CARINYA PARC** in Marcellus; **CP** monogram for squares. No pictorial mark.
 
 ## Production vs prototype
 
 - **Production (this repo):** reuse `apps/site/src/components/ui/` (Base UI + Tailwind). Do not invent a parallel component set. Site-specific CSS stays in `apps/site/src/styles/`.
-- **Throwaway mocks:** static HTML is fine; still use token names and the visual rules above. Do not treat design-system JSX as a production import.
-
-HTML brand decks and specimen cards live in the sibling `design-system` repo (studio only). They are not the token or voice source of truth.
+- **Throwaway mocks:** static HTML is fine; use the token names and visual rules above. Prototype inside the Next app when you need Tailwind. Do not invent a second token sheet.


### PR DESCRIPTION
## Summary

The website still depended on the sibling design-system repo for type-scale names and skill pointers, so that repo could not be deleted. This change adds the named type and tracking tokens to `@carinya/theme` and makes `skills/carinya-parc` resolve only inside this repository.

## What changed

- `@carinya/theme` now exposes `text-display` … `text-eyebrow`, `tracking-eyebrow`, `tracking-wordmark`, and matching leading tokens. Colour, radius, shadow, and semantic tokens were already complete.
- Theme README is the token inventory (including what stays as Tailwind defaults).
- Product skill no longer mentions design-system; it points at `public/images/` and `public/motifs/`.
- `structure.md` documents `public/motifs/`.

HTML brand decks, prototype JSX, and specimen cards are not ported. After merge, design-system can be deleted.

## Why

Production tokens and voice already lived here. The leftover type scale and sibling-repo skill lines were the last blockers to deleting the studio repo.

## How to verify

- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm format:check`, `pnpm test`, and `pnpm --filter site import:content-seeds:validate` pass locally (ran before push).
- [ ] Tailwind utilities such as `tracking-eyebrow` / `text-body` resolve from `@carinya/theme` (no visual rewrite of existing pages in this PR).
- [ ] `skills/carinya-parc/SKILL.md` has no `design-system` path.

## Linked work

No tracked work item — follow-up to #110, #111, and #112 so the design-system repo can be deleted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified Carinya Parc’s canonical brand positioning source.
  - Documented the locations of brand line-art motifs and image assets.
  - Expanded theme guidance for ownership, design tokens, spacing, borders, typography, and font loading.
  - Added clearer guidance for typography scales, visual styling, focus states, transitions, wordmarks, icons, and prototype placement.

- **Style**
  - Added shared typography tokens covering display text, headings, body copy, eyebrow labels, and wordmarks, including sizing, line height, tracking, and font weights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->