### PR TITLE
fix(deps): patch nanoid 3.x for CVE-2026-67213

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,7 @@ updates:
           - '@swc/helpers'
           - 'dompurify'
           - 'esbuild'
+          - 'nanoid'
           - 'postcss'
       # Remaining apps/site dependencies.
       site:
@@ -63,6 +64,7 @@ updates:
           - '@swc/helpers'
           - 'dompurify'
           - 'esbuild'
+          - 'nanoid'
           - 'postcss'
     commit-message:
       prefix: 'chore'

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
       "@swc/helpers": "0.5.23",
       "dompurify": ">=3.4.11",
       "esbuild": ">=0.25.0",
+      "nanoid@<3.3.18": "3.3.18",
       "postcss": ">=8.5.10",
       "webpack": "5.109.2"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   '@swc/helpers': 0.5.23
   dompurify: '>=3.4.11'
   esbuild: '>=0.25.0'
+  nanoid@<3.3.18: 3.3.18
   postcss: '>=8.5.10'
   webpack: 5.109.2
 
@@ -4486,11 +4487,6 @@ packages:
   mute-stream@3.0.0:
     resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
     engines: {node: ^20.17.0 || >=22.9.0}
-
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
 
   nanoid@3.3.18:
     resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
@@ -10538,8 +10534,6 @@ snapshots:
   mute-stream@3.0.0:
     optional: true
 
-  nanoid@3.3.16: {}
-
   nanoid@3.3.18: {}
 
   napi-postinstall@0.3.4: {}
@@ -11017,7 +11011,7 @@ snapshots:
 
   postcss@8.5.20:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
## Summary

Dependabot alert [#199](https://github.com/carinyaparc/carinyaparc/security/dependabot/199) is a high-severity DoS in `nanoid` (`CVE-2026-67213` / `GHSA-2v37-7h3g-55p8`). The copy used by `postcss@8.5.26` is already on `3.3.18`; `@tailwindcss/postcss` still resolved `postcss@8.5.20` → `nanoid@3.3.16`.

This adds a targeted `pnpm.overrides` entry so the 3.x line moves to `3.3.18`.

## What changed

- Root override `nanoid@<3.3.18` → `3.3.18`
- Lockfile snapshot for `postcss@8.5.20` now depends on `3.3.18`
- Dependabot workspace group includes `nanoid` so later override bumps stay with the other root pins

## Why

No Dependabot PR existed for this transitive alert. GitHub will keep the high-severity alert open until the lockfile is patched. Same override pattern as the earlier security-alert cleanup.

## How to verify

- `pnpm install --frozen-lockfile`
- Confirm `pnpm-lock.yaml` has `nanoid@3.3.18` and no `3.3.16`
- After merge, confirm alert 199 closes on GitHub's rescan

## Linked work

Relates to Dependabot alert 199. No tracked work item.

## Reviewer notes

Exploitability is low here: the hang requires an unvalidated size of `0` passed to `customAlphabet` / `customRandom`. Production CSS generation does not take attacker-controlled nanoid sizes, but the lockfile still needs the patched version for the alert to close.
